### PR TITLE
Switch Command Line Interface to use optparse-applicative

### DIFF
--- a/camfort.cabal
+++ b/camfort.cabal
@@ -88,7 +88,8 @@ executable camfort
                         binary >= 0.8.3.0,
                         lattices >= 1.5,
                         sbv >= 5.14,
-                        partial-order >= 0.1.2
+                        partial-order >= 0.1.2,
+                        optparse-applicative >= 0.13.2.0
   default-language: Haskell2010
 
 library

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -74,6 +74,14 @@ import qualified Data.Map.Strict as M
 data AnnotationType = ATDefault | Doxygen | Ford
 
 
+-- | Retrieve the marker character compatible with the given
+-- type of annotation.
+markerChar :: AnnotationType -> Char
+markerChar Doxygen   = '<'
+markerChar Ford      = '!'
+markerChar ATDefault = '='
+
+
 -- * Wrappers on all of the features
 ast d excludes = do
     xs <- readParseSrcDir d excludes
@@ -161,12 +169,10 @@ unitsCompile inSrc excludes m debug incDir outSrc = do
     let rfun = LU.compileUnits uo
     putStrLn =<< doCreateBinary rfun inSrc excludes outSrc =<< getModFiles incDir
 
+
 unitsSynth inSrc excludes m debug incDir outSrc annType = do
     putStrLn $ "Synthesising units for '" ++ inSrc ++ "'"
-    let marker = case annType of
-                   Doxygen   -> '<'
-                   Ford      -> '!'
-                   ATDefault -> '='
+    let marker = markerChar annType
     uo <- optsToUnitOpts m debug incDir
     let rfun =
           mapM (LU.synthesiseUnits uo marker)
@@ -193,10 +199,6 @@ stencilsInfer inSrc excludes outSrc inferMode = do
 
 stencilsSynth inSrc excludes outSrc inferMode annType = do
    putStrLn $ "Synthesising stencil specs for '" ++ inSrc ++ "'"
-   let marker = case annType of
-                  Doxygen   -> '<'
-                  Ford      -> '!'
-                  ATDefault -> '='
-   let rfun = Stencils.synth inferMode marker
+   let rfun = Stencils.synth inferMode (markerChar annType)
    report <- doRefactor rfun inSrc excludes outSrc
    putStrLn report

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -23,7 +23,27 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Camfort.Functionality where
+module Camfort.Functionality (
+  -- * Datatypes
+    AnnotationType(..)
+  -- * Commands
+  , ast
+  , countVarDecls
+  -- ** Stencil Analysis
+  , stencilsCheck
+  , stencilsInfer
+  , stencilsSynth
+  -- ** Unit Analysis
+  , unitsCriticals
+  , unitsCheck
+  , unitsInfer
+  , unitsSynth
+  , unitsCompile
+  -- ** Refactorings
+  , common
+  , dead
+  , equivalences
+  , datatypes) where
 
 import System.FilePath
 import Control.Monad

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -51,17 +51,18 @@ import qualified Data.Map.Strict as M
 
 -- CamFort optional flags
 data Flag = Version
-         | Input String
-         | Output String
-         | Excludes String
-         | IncludeDir String
-         | Literals LiteralsOpt
-         | StencilInferMode Stencils.InferMode
-         | Doxygen
-         | Ford
-         | FVersion String
-         | RefactorInPlace
-         | Debug deriving (Data, Show, Eq)
+          | Help
+          | Input String
+          | Output String
+          | Excludes String
+          | IncludeDir String
+          | Literals LiteralsOpt
+          | StencilInferMode Stencils.InferMode
+          | Doxygen
+          | Ford
+          | FVersion String
+          | RefactorInPlace
+          | Debug deriving (Data, Show, Eq)
 
 type Options = [Flag]
 

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -155,13 +155,13 @@ unitsInfer inSrc excludes m debug incDir = do
     let rfun = concatMap (LU.inferUnits uo)
     doAnalysisReportWithModFiles rfun putStrLn inSrc excludes =<< getModFiles incDir
 
-unitsCompile inSrc excludes outSrc m debug incDir = do
+unitsCompile inSrc excludes m debug incDir outSrc = do
     putStrLn $ "Compiling units for '" ++ inSrc ++ "'"
     uo <- optsToUnitOpts m debug incDir
     let rfun = LU.compileUnits uo
     putStrLn =<< doCreateBinary rfun inSrc excludes outSrc =<< getModFiles incDir
 
-unitsSynth inSrc excludes outSrc annType m debug incDir = do
+unitsSynth inSrc excludes m debug incDir outSrc annType = do
     putStrLn $ "Synthesising units for '" ++ inSrc ++ "'"
     let marker = case annType of
                    Doxygen   -> '<'
@@ -173,7 +173,7 @@ unitsSynth inSrc excludes outSrc annType m debug incDir = do
     report <- doRefactorWithModFiles rfun inSrc excludes outSrc =<< getModFiles incDir
     putStrLn report
 
-unitsCriticals inSrc excludes outSrc m debug incDir = do
+unitsCriticals inSrc excludes m debug incDir outSrc = do
     putStrLn $ "Suggesting variables to annotate with unit specifications in '"
              ++ inSrc ++ "'"
     uo <- optsToUnitOpts m debug incDir

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -50,169 +50,133 @@ import Language.Fortran.Util.ModFile
 import qualified Camfort.Specification.Stencils as Stencils
 import qualified Data.Map.Strict as M
 
--- CamFort optional flags
-data Flag = Version
-          | Help
-          | Input String
-          | Output String
-          | Excludes String
-          | IncludeDir String
-          | Literals LiteralsOpt
-          | StencilInferMode Stencils.InferMode
-          | Doxygen
-          | Ford
-          | FVersion String
-          | RefactorInPlace
-          | Debug deriving (Data, Show, Eq)
 
-type Options = [Flag]
+data AnnotationType = ATDefault | Doxygen | Ford
 
--- Extract excludes information from options
-instance Default String where
-    defaultValue = ""
-getExcludes :: Options -> String
-getExcludes opts = head ([ e | Excludes e <- universeBi opts ] ++ [""])
-
--- Separates the comma-separated filenames
-getExcludedFiles :: Options -> [String]
-getExcludedFiles = map unpack . split (==',') . pack . getExcludes
 
 -- * Wrappers on all of the features
-ast d excludes _ _ = do
+ast d excludes = do
     xs <- readParseSrcDir d excludes
     print (map (\(_, _, p) -> p) xs)
 
-countVarDecls inSrc excludes _ _ = do
+countVarDecls inSrc excludes = do
     putStrLn $ "Counting variable declarations in '" ++ inSrc ++ "'"
     doAnalysisSummary countVariableDeclarations inSrc excludes Nothing
 
-dead inSrc excludes outSrc _ = do
+dead inSrc excludes outSrc = do
     putStrLn $ "Eliminating dead code in '" ++ inSrc ++ "'"
     report <- doRefactor (mapM (deadCode False)) inSrc excludes outSrc
     putStrLn report
 
-common inSrc excludes outSrc _ = do
+common inSrc excludes outSrc = do
     putStrLn $ "Refactoring common blocks in '" ++ inSrc ++ "'"
     isDir <- isDirectory inSrc
     let rfun = commonElimToModules (takeDirectory outSrc ++ "/")
     report <- doRefactorAndCreate rfun inSrc excludes outSrc
     putStrLn report
 
-equivalences inSrc excludes outSrc _ = do
+equivalences inSrc excludes outSrc = do
     putStrLn $ "Refactoring equivalences blocks in '" ++ inSrc ++ "'"
     report <- doRefactor (mapM refactorEquivalences) inSrc excludes outSrc
     putStrLn report
 
-datatypes inSrc excludes outSrc _ = do
+datatypes inSrc excludes outSrc = do
     putStrLn $ "Introducing derived data types in '" ++ inSrc ++ "'"
     report <- doRefactor dataTypeIntro inSrc excludes outSrc
     putStrLn report
 
 {- Units feature -}
-optsToUnitOpts :: [Flag] -> IO UnitOpts
-optsToUnitOpts = foldM (\ o f -> do
-  case f of
-    Literals m   -> return $ o { uoLiterals    = m }
-    Debug        -> return $ o { uoDebug       = True }
-    IncludeDir d -> do
-      -- Figure out the camfort mod files and parse them.
-      modFileNames <- filter isModFile `fmap` rGetDirContents' d
-      assocList <- forM modFileNames $ \ modFileName -> do
-        eResult <- decodeFileOrFail (d ++ "/" ++ modFileName) -- FIXME, directory manipulation
-        case eResult of
-          Left (offset, msg) -> do
-            putStrLn $ modFileName ++ ": Error at offset " ++ show offset ++ ": " ++ msg
-            return (modFileName, emptyModFile)
-          Right modFile -> do
-            putStrLn $ modFileName ++ ": successfully parsed precompiled file."
-            return (modFileName, modFile)
-      return $ o { uoModFiles = M.fromList assocList `M.union` uoModFiles o }
-    _            -> return o
-    ) unitOpts0
+optsToUnitOpts :: LiteralsOpt -> Bool -> Maybe String -> IO UnitOpts
+optsToUnitOpts m debug = maybe (pure o1) (\d -> do
+  -- Figure out the camfort mod files and parse them.
+  modFileNames <- filter isModFile `fmap` rGetDirContents' d
+  assocList <- forM modFileNames $ \ modFileName -> do
+    eResult <- decodeFileOrFail (d ++ "/" ++ modFileName) -- FIXME, directory manipulation
+    case eResult of
+      Left (offset, msg) -> do
+        putStrLn $ modFileName ++ ": Error at offset " ++ show offset ++ ": " ++ msg
+        return (modFileName, emptyModFile)
+      Right modFile -> do
+        putStrLn $ modFileName ++ ": successfully parsed precompiled file."
+        return (modFileName, modFile)
+  return $ o1 { uoModFiles = M.fromList assocList })
+  -- return $ o1 { uoModFiles = M.fromList assocList `M.union` uoModFiles o })
+  where o1 = unitOpts0 { uoLiterals = m
+                       , uoDebug = debug
+                       , uoModFiles = M.empty }
 
-getModFiles :: [Flag] -> IO ModFiles
-getModFiles = foldM (\ modFiles f -> do
-  case f of
-    IncludeDir d -> do
-      -- Figure out the camfort mod files and parse them.
-      modFileNames <- filter isModFile `fmap` rGetDirContents' d
-      addedModFiles <- forM modFileNames $ \ modFileName -> do
-        eResult <- decodeFileOrFail (d ++ "/" ++ modFileName) -- FIXME, directory manipulation
-        case eResult of
-          Left (offset, msg) -> do
-            putStrLn $ modFileName ++ ": Error at offset " ++ show offset ++ ": " ++ msg
-            return emptyModFile
-          Right modFile -> do
-            putStrLn $ modFileName ++ ": successfully parsed precompiled file."
-            return modFile
-      return $ addedModFiles ++ modFiles
-    _            -> return modFiles
-    ) emptyModFiles
+
+getModFiles :: Maybe String -> IO ModFiles
+getModFiles = maybe (pure emptyModFiles) (\d -> do
+  -- Figure out the camfort mod files and parse them.
+  modFileNames <- filter isModFile `fmap` rGetDirContents' d
+  addedModFiles <- forM modFileNames $ \ modFileName -> do
+    eResult <- decodeFileOrFail (d ++ "/" ++ modFileName) -- FIXME, directory manipulation
+    case eResult of
+      Left (offset, msg) -> do
+        putStrLn $ modFileName ++ ": Error at offset " ++ show offset ++ ": " ++ msg
+        return emptyModFile
+      Right modFile -> do
+        putStrLn $ modFileName ++ ": successfully parsed precompiled file."
+        return modFile
+  return addedModFiles)
 
 isModFile = (== modFileSuffix) . fileExt
 
--- | Retrieve the inference mode provided in the options (or a default mode).
-getInferMode :: Options -> Stencils.InferMode
-getInferMode [] = defaultValue
-getInferMode (x : xs) =
-    case x of
-      StencilInferMode mode -> mode
-      _ -> getInferMode xs
-
-unitsCheck inSrc excludes _ opt = do
+unitsCheck inSrc excludes m debug incDir = do
     putStrLn $ "Checking units for '" ++ inSrc ++ "'"
-    uo <- optsToUnitOpts opt
+    uo <- optsToUnitOpts m debug incDir
     let rfun = concatMap (LU.checkUnits uo)
-    doAnalysisReportWithModFiles rfun putStrLn inSrc excludes =<< getModFiles opt
+    doAnalysisReportWithModFiles rfun putStrLn inSrc excludes =<< getModFiles incDir
 
-unitsInfer inSrc excludes _ opt = do
+unitsInfer inSrc excludes m debug incDir = do
     putStrLn $ "Inferring units for '" ++ inSrc ++ "'"
-    uo <- optsToUnitOpts opt
+    uo <- optsToUnitOpts m debug incDir
     let rfun = concatMap (LU.inferUnits uo)
-    doAnalysisReportWithModFiles rfun putStrLn inSrc excludes =<< getModFiles opt
+    doAnalysisReportWithModFiles rfun putStrLn inSrc excludes =<< getModFiles incDir
 
-unitsCompile inSrc excludes outSrc opt = do
+unitsCompile inSrc excludes outSrc m debug incDir = do
     putStrLn $ "Compiling units for '" ++ inSrc ++ "'"
-    uo <- optsToUnitOpts opt
+    uo <- optsToUnitOpts m debug incDir
     let rfun = LU.compileUnits uo
-    putStrLn =<< doCreateBinary rfun inSrc excludes outSrc =<< getModFiles opt
+    putStrLn =<< doCreateBinary rfun inSrc excludes outSrc =<< getModFiles incDir
 
-unitsSynth inSrc excludes outSrc opt = do
+unitsSynth inSrc excludes outSrc annType m debug incDir = do
     putStrLn $ "Synthesising units for '" ++ inSrc ++ "'"
-    let marker
-         | Doxygen `elem` opt = '<'
-         | Ford `elem` opt = '!'
-         | otherwise = '='
-    uo <- optsToUnitOpts opt
+    let marker = case annType of
+                   Doxygen   -> '<'
+                   Ford      -> '!'
+                   ATDefault -> '='
+    uo <- optsToUnitOpts m debug incDir
     let rfun =
           mapM (LU.synthesiseUnits uo marker)
-    report <- doRefactorWithModFiles rfun inSrc excludes outSrc =<< getModFiles opt
+    report <- doRefactorWithModFiles rfun inSrc excludes outSrc =<< getModFiles incDir
     putStrLn report
 
-unitsCriticals inSrc excludes outSrc opt = do
+unitsCriticals inSrc excludes outSrc m debug incDir = do
     putStrLn $ "Suggesting variables to annotate with unit specifications in '"
              ++ inSrc ++ "'"
-    uo <- optsToUnitOpts opt
+    uo <- optsToUnitOpts m debug incDir
     let rfun = mapM (LU.inferCriticalVariables uo)
-    doAnalysisReportWithModFiles rfun (putStrLn . fst) inSrc excludes =<< getModFiles opt
+    doAnalysisReportWithModFiles rfun (putStrLn . fst) inSrc excludes =<< getModFiles incDir
 
 {- Stencils feature -}
-stencilsCheck inSrc excludes _ _ = do
+stencilsCheck inSrc excludes = do
    putStrLn $ "Checking stencil specs for '" ++ inSrc ++ "'"
    let rfun = \f p -> (Stencils.check f p, p)
    doAnalysisSummary rfun inSrc excludes Nothing
 
-stencilsInfer inSrc excludes outSrc opt = do
+stencilsInfer inSrc excludes outSrc inferMode = do
    putStrLn $ "Inferring stencil specs for '" ++ inSrc ++ "'"
-   let rfun = Stencils.infer (getInferMode opt) '='
+   let rfun = Stencils.infer inferMode '='
    doAnalysisSummary rfun inSrc excludes (Just outSrc)
 
-stencilsSynth inSrc excludes outSrc opt = do
+stencilsSynth inSrc excludes outSrc inferMode annType = do
    putStrLn $ "Synthesising stencil specs for '" ++ inSrc ++ "'"
-   let marker
-        | Doxygen `elem` opt = '<'
-        | Ford `elem` opt = '!'
-        | otherwise = '='
-   let rfun = Stencils.synth (getInferMode opt) marker
+   let marker = case annType of
+                  Doxygen   -> '<'
+                  Ford      -> '!'
+                  ATDefault -> '='
+   let rfun = Stencils.synth inferMode marker
    report <- doRefactor rfun inSrc excludes outSrc
    putStrLn report

--- a/src/Camfort/Input.hs
+++ b/src/Camfort/Input.hs
@@ -22,7 +22,6 @@ Handles input of code base (files and directories)
 -}
 
 {-# LANGUAGE DoAndIfThenElse #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Camfort.Input where
 
@@ -38,7 +37,6 @@ import qualified Data.ByteString.Char8 as B
 import Data.Data
 import Data.Char (toUpper)
 import Data.Maybe
-import Data.Generics.Uniplate.Operations
 import Data.List (foldl', nub, (\\), elemIndices, intercalate)
 import Data.Monoid
 import Data.Text.Encoding.Error (replace)
@@ -49,15 +47,6 @@ import System.Directory
 -- Class for default values of some type 't'
 class Default t where
     defaultValue :: t
-
--- From a '[t]' extract the first occurence of an 'opt' value.
--- If one does not exist, return the default 'opt'
-getOption :: forall t opt . (Data opt, Data t, Default opt) => [t] -> opt
-getOption [] = defaultValue
-getOption (x : xs) =
-    case universeBi x :: [opt] of
-      []        -> getOption xs
-      (opt : _) -> opt
 
 -- * Builders for analysers and refactorings
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -146,10 +146,12 @@ readOptions = liftA ReadOptions
   <*> excludeOption
 
 
+-- | User must specify either an ouput file, or say that the file
+-- | should be rewritten in place.
 writeOptions :: Parser WriteOptions
 writeOptions = (liftA WriteFile . fileArgument $
                  help "file to write output to")
-               <|> (pure WriteInplace <* flag' True
+               <|> (pure WriteInplace <* flag' ()
                      (   long "inplace"
                       <> help "write in place (replaces input files)"))
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -22,234 +22,381 @@ import Data.Foldable (find)
 import System.Console.GetOpt
 import System.Environment
 
-import Camfort.Helpers
+import Camfort.Helpers hiding ((<>))
+import Camfort.Input (defaultValue)
 import Camfort.Functionality
+import Camfort.Specification.Stencils (InferMode)
+import Camfort.Specification.Units.Monad (LiteralsOpt(LitMixed))
 
+import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>))
 import Data.Text (pack, unpack, split)
 
-
--- | The entry point to CamFort. Displays user information, and
--- | handles which functionality is being requested
-main :: IO ()
-main = do
-  args <- getArgs
-  (opts,posArgs) <- compilerOpts args
-  case opts of
-    (Version:_) -> displayVersion
-    (Help:_)    -> displayHelp
-    _           -> do
-      if length args >= 2 then
-        let (f : (inp : _)) = args
-        in case lookupFunctionality f functionalities of
-          Nothing -> putStrLn fullUsageInfo
-          Just func -> do
-            (numReqArgs, outp) <-
-              if RefactorInPlace `elem` opts
-              -- Does not check to see if an output directory
-              -- is also specified since flags come last and therefore
-              -- override any specification of an output directory
-              -- (which would come earlier).
-                then return (2, inp)
-                else case outputFileReq func of
-                  OutputFileNotReq ->
-                    if length args >= 3 && (head (args !! 2) == '-')
-                      then
-                        return (2, "")
-                      else -- case where an unnecessary output is specified
-                        return (3, "")
-                  OutputFileReq ->
-                    if length args >= 3
-                      then return (3, args !! 2)
-                      else fail $ usage ++ "\nThis mode requires an output\
-                                          \ file/directory to be specified\n\
-                                          \ or use the --inplace flag to set\
-                                          \ the ouput location to be the input\
-                                          \ location."
-            let excluded_files = map unpack . split (==',') . pack . getExcludes
-            fun func inp (excluded_files opts) outp opts
-      else do
-        putStrLn versionMessage
-        if length args == 1
-        then putStrLn $ usage ++ "Please specify an input file/directory"
-        else putStrLn fullUsageInfo
+import Options.Applicative
 
 
--- | Usage information, including descriptions of supported functions.
-fullUsageInfo = usageInfo (usage ++ menu ++ "\nOptions:") options
+-- | Commands supported by CamFort.
+data Command = CmdCount ReadOptions
+             | CmdAST ReadOptions
+             | CmdStencilsCheck ReadOptions
+             | CmdStencilsInfer StencilsOptions
+             | CmdStencilsSynth StencilsSynthOptions
+             | CmdUnitsSuggest UnitsWriteOptions
+             | CmdUnitsCheck UnitsOptions
+             | CmdUnitsInfer UnitsOptions
+             | CmdUnitsSynth UnitsSynthOptions
+             | CmdUnitsCompile UnitsWriteOptions
+             | CmdRefactCommon RefactOptions
+             | CmdRefactDead RefactOptions
+             | CmdRefactEquivalence RefactOptions
+             | CmdRefactDatatype RefactOptions
+             | CmdTopVersion
 
 
-options :: [OptDescr Flag]
-options =
-     [ Option ['v','?'] ["version"] (NoArg Version)
-         "show version number"
-     , Option [] ["help"] (NoArg Help)
-         "show this help message and exit"
-     , Option [] ["inplace"] (NoArg RefactorInPlace)
-         "refactor in place (replaces input files)"
-     , Option ['e'] ["exclude"] (ReqArg Excludes "FILES")
-         "files to exclude (comma separated list, no spaces)"
-     , Option ['l'] ["units-literals"] (ReqArg (Literals . read) "ID")
-         "units-of-measure literals mode. ID = Unitless, Poly, or Mixed"
-     , Option ['m'] ["stencil-inference-mode"]
-                (ReqArg (StencilInferMode . read . (++ "Mode")) "ID")
-                "stencil specification inference mode. ID = Do, Assign, or Both"
-     , Option ['I'] ["include-dir"] (ReqArg IncludeDir "DIR")
-                "directory to search for precompiled files"
-     , Option [] ["debug"] (NoArg Debug)
-         "enable debug mode"
-     , Option [] ["doxygen"] (NoArg Doxygen)
-         "synthesise annotations compatible with Doxygen"
-     , Option [] ["ford"] (NoArg Ford)
-         "synthesise annotations compatible with Ford"
-     ]
-
-
--- | Wrapper around 'getOpt' to provide usage information
--- upon failure.
-compilerOpts :: [String] -> IO ([Flag], [String])
-compilerOpts argv =
-  case getOpt Permute options argv of
-    (o,n,[]  ) -> return (o,n)
-    (_,_,errs) -> ioError (userError (concat errs ++ helpPrompt))
-  where helpPrompt = "Try camfort --help for more information."
-
-
--- | Functionality provided by the system, i.e. this is the
--- wiring between the outward facing command line interface and our internal
--- functions.
-data Functionality = Functionality
-  { commandName   :: String         -- ^ Command invoked by user at the cli
-  , altNames      :: [String]       -- ^ Alternative command names
-                                    -- ^ Function to dispatch to
-  , fun           :: FileOrDir -> [Filename] -> FileOrDir -> Options -> IO ()
-  , info          :: String         -- ^ Description of functionality
-  , outputFileReq :: OutputFileReq  -- ^ Whether an output file is required
+-- | Options for reading files.
+data ReadOptions = ReadOptions
+  { inputSource :: String
+  , exclude     :: Maybe [String]
   }
 
 
--- | Tag to distinguish whether a functionality requires an output file.
-data OutputFileReq = OutputFileReq | OutputFileNotReq
+-- | Options for writing to files.
+--
+-- User can choose to either specify which file to write, or have
+-- the input files be written over.
+data WriteOptions = WriteFile { outputFile :: String }
+                  | WriteInplace
 
 
--- | Resolve some text into CamFort functionality.
-lookupFunctionality :: String -> [Functionality] -> Maybe Functionality
-lookupFunctionality str = find (getFunctionality str)
-  where getFunctionality s f | commandName f == s  = True
-                             | s `elem` altNames f = True
-                             | otherwise           = False
+-- | Options used by stencil commands.
+data StencilsOptions = StencilsOptions
+  { soReadOptions  :: ReadOptions
+  , soWriteOptions :: WriteOptions
+  , soInferMode    :: InferMode
+  }
 
 
--- | The functionalties that Camfort provides
-functionalities :: [Functionality]
-functionalities = analyses ++ refactorings
+-- | Options used by all unit commands.
+data UnitsOptions = UnitsOptions
+  { uoReadOptions :: ReadOptions
+  , literals      :: LiteralsOpt
+  , debug         :: Bool
+  , includeDir    :: Maybe String
+  }
 
 
--- | Functionality for analysis.
-analyses :: [Functionality]
-analyses =
-  [ Functionality
-      "count"
-      []
-      countVarDecls
-      "count variable declarations"
-      OutputFileNotReq
-
-  , Functionality
-      "ast"
-      []
-      ast
-      "print the raw AST -- for development purposes"
-      OutputFileNotReq
-
-  , Functionality
-      "stencils-check"
-      ["stencil-check", "check-stencils", "check-stencil"]
-      stencilsCheck
-      "stencil spec checking"
-      OutputFileNotReq
-
-  , Functionality
-      "stencils-infer"
-      ["stencil-infer", "infer-stencils", "infer-stencil"]
-      stencilsInfer
-      "stencil spec inference"
-      OutputFileNotReq
-
-  , Functionality
-      "stencils-synth"
-      ["stencil-synth", "synth-stencils", "synth-stencil"]
-      stencilsSynth
-      "stencil spec synthesis"
-      OutputFileReq
-
-  , Functionality
-      "units-suggest"
-      ["unit-suggest", "suggest-units", "suggest-unit", "units-criticals"]
-      unitsCriticals
-      "suggest variables to annotate with units-of-measure for maximum coverage"
-      OutputFileNotReq
-
-  , Functionality
-      "units-check"
-      ["unit-check", "check-units", "check-unit"]
-      unitsCheck
-      "unit-of-measure checking"
-      OutputFileNotReq
-
-  , Functionality
-      "units-infer"
-      ["unit-infer", "infer-units", "infer-unit"]
-      unitsInfer
-      "unit-of-measure inference"
-      OutputFileNotReq
-
-  , Functionality
-      "units-synth"
-      ["unit-synth", "synth-units", "synth-unit"]
-      unitsSynth
-      "unit-of-measure synthesise specs"
-      OutputFileReq
-
-  , Functionality
-      "units-compile"
-      ["unit-compile", "compile-units", "compile-unit"]
-      unitsCompile
-      "units-of-measure compile module information"
-      OutputFileReq
-  ]
+data UnitsWriteOptions = UnitsWriteOptions
+  { uwoUnitsOptions :: UnitsOptions
+  , uwoWriteOptions :: WriteOptions
+  }
 
 
--- | Functionality for refactoring.
-refactorings :: [Functionality]
-refactorings =
-  [ Functionality
-      "common"
-      ["commons"]
-      common
-      "common block elimination"
-      OutputFileReq
+newtype AnnotationOptions =
+  AnnotationOptions { annotationType :: AnnotationType }
 
-  , Functionality
-      "equivalence"
-      ["equivalences"]
-      equivalences
-      "equivalence elimination"
-      OutputFileReq
 
-  , Functionality
-      "dead"
-      []
-      dead
-      "dead-code elimination"
-      OutputFileReq
+data UnitsSynthOptions = UnitsSynthOptions
+  { usoUnitsWriteOptions :: UnitsWriteOptions
+  , usoAnnotationOptions :: AnnotationOptions
+  }
 
-  , Functionality
-      "datatype"
-      ["datatypes"]
-      datatypes
-      "derived data type introduction"
-      OutputFileReq
-  ]
+
+data StencilsSynthOptions = StencilsSynthOptions
+  { ssoStencilsOptions    :: StencilsOptions
+  , ssoAnnotationOptions  :: AnnotationOptions
+  }
+
+
+-- | Options used by refactoring commands.
+data RefactOptions = RefactOptions
+  { rfoReadOptions  :: ReadOptions
+  , rfoWriteOptions :: WriteOptions
+  }
+
+
+-- | Parser for an argument representing an individual file or directory.
+fileArgument :: Mod ArgumentFields String -> Parser String
+fileArgument m = strArgument (metavar "FILENAME" <> action "file" <> m)
+
+
+-- | Parser for file options with multiple files specified
+-- | as a comma-separated list.
+multiFileOption :: Mod OptionFields [String] -> Parser [String]
+multiFileOption m = option (list str)
+                    (metavar "FILE..." <> action "file" <> m)
+  where list :: ReadM String -> ReadM [String]
+        list = fmap (splitBy ',')
+        splitBy c [] = []
+        splitBy c xs = case break (==c) xs of
+                         (xs', [])     -> [xs']
+                         (xs', _:cs) -> xs' : splitBy c cs
+
+
+excludeOption :: Parser (Maybe [String])
+excludeOption = optional $ multiFileOption $
+     long "exclude"
+  <> short 'e'
+  <> help "files to exclude (comma separated list, no spaces)"
+
+
+-- | Parse options for 'ReadOptions'.
+readOptions :: Parser ReadOptions
+readOptions = liftA ReadOptions
+  (fileArgument $ help "input file")
+  <*> excludeOption
+
+
+writeOptions :: Parser WriteOptions
+writeOptions = (liftA WriteFile . fileArgument $
+                 help "file to write output to")
+               <|> (pure WriteInplace <* switch
+                     (   long "inplace"
+                      <> help "write in place (replaces input files)"))
+
+
+stencilsOptions :: Parser StencilsOptions
+stencilsOptions = liftA StencilsOptions
+  readOptions <*> writeOptions <*> inferModeOption
+  where
+    inferModeOption = fmap (fromMaybe defaultValue)
+                      . optional . option readInferOption $
+      (    metavar "INFER-MODE"
+        <> completeWith ["Assign", "Do", "Both"]
+        <> long "stencil-inference-mode"
+        <> short 'm'
+        <> help "stencil specification inference mode. ID = Do, Assign, or Both")
+    readInferOption = fmap parseInfer str
+    -- TODO: Make this more robust
+    -- This can encounter a read error, we should
+    -- ensure that we can't reach this point
+    -- with invalid mode.
+    parseInfer = read . (++"Mode")
+
+
+stencilsSynthOptions :: Parser StencilsSynthOptions
+stencilsSynthOptions = liftA StencilsSynthOptions
+  stencilsOptions <*> annotationOptions
+
+
+unitsOptions :: Parser UnitsOptions
+unitsOptions = liftA UnitsOptions
+      readOptions
+  <*> literalsOption
+  <*> debugOption
+  <*> optional includeDirOption
+  where
+    literalsOption = option parseLiterals $
+                     long "units-literals"
+                     <> short 'l'
+                     <> metavar "ID"
+                     <> completeWith ["Unitless", "Poly", "Mixed"]
+                     <> value LitMixed
+                     <> help "units-of-measure literals mode. ID = Unitless, Poly, or Mixed"
+    parseLiterals = fmap read str
+    debugOption = switch (long "debug" <> help "enable debug mode")
+    dirOption m = strOption (metavar "DIR" <> action "directory" <> m)
+    includeDirOption = dirOption
+      (   long "include-dir"
+       <> short 'I'
+       <> help "directory to search for precompiled files")
+
+
+unitsWriteOptions :: Parser UnitsWriteOptions
+unitsWriteOptions = liftA UnitsWriteOptions
+  unitsOptions <*> writeOptions
+
+
+annotationOptions :: Parser AnnotationOptions
+annotationOptions = liftA AnnotationOptions $
+  flag ATDefault Doxygen
+    (long "doxygen" <> help "synthesise annotations compatible with Doxygen")
+  <|> flag ATDefault Ford
+    (long "ford" <> help "synthesise annotations compatible with Ford")
+
+
+unitsSynthOptions :: Parser UnitsSynthOptions
+unitsSynthOptions = liftA UnitsSynthOptions
+  unitsWriteOptions <*> annotationOptions
+
+
+refactOptions :: Parser RefactOptions
+refactOptions = liftA RefactOptions
+  readOptions <*> writeOptions
+
+
+cmdCount, cmdAST :: Parser Command
+cmdCount = liftA CmdCount readOptions
+cmdAST   = liftA CmdAST   readOptions
+
+
+cmdStencilsCheck, cmdStencilsInfer, cmdStencilsSynth :: Parser Command
+cmdStencilsCheck = liftA CmdStencilsCheck readOptions
+cmdStencilsInfer = liftA CmdStencilsInfer stencilsOptions
+cmdStencilsSynth = liftA CmdStencilsSynth stencilsSynthOptions
+
+
+cmdUnitsSuggest, cmdUnitsCheck, cmdUnitsInfer
+  , cmdUnitsSynth, cmdUnitsCompile :: Parser Command
+cmdUnitsSuggest = liftA CmdUnitsSuggest unitsWriteOptions
+cmdUnitsCheck   = liftA CmdUnitsCheck   unitsOptions
+cmdUnitsInfer   = liftA CmdUnitsInfer   unitsOptions
+cmdUnitsSynth   = liftA CmdUnitsSynth   unitsSynthOptions
+cmdUnitsCompile = liftA CmdUnitsCompile unitsWriteOptions
+
+
+cmdRefactCommon, cmdRefactDatatype
+  , cmdRefactDead, cmdRefactEquivalence :: Parser Command
+cmdRefactCommon      = liftA CmdRefactCommon refactOptions
+cmdRefactDatatype    = liftA CmdRefactDatatype refactOptions
+cmdRefactDead        = liftA CmdRefactDead refactOptions
+cmdRefactEquivalence = liftA CmdRefactEquivalence refactOptions
+
+
+analysesParser :: Parser Command
+analysesParser = hsubparser $
+     (command "count" . info cmdCount
+       . progDesc $ "count variable declarations")
+  <> (command "ast" . info cmdAST
+       . progDesc $ "print the raw AST -- for development purposes")
+  <> (command "stencils-check" . info cmdStencilsCheck
+       . progDesc $ "stencil spec checking")
+  <> (command "stencils-infer" . info cmdStencilsInfer
+       . progDesc $ "stencil spec inference")
+  <> (command "stencils-synth" . info cmdStencilsSynth
+       . progDesc $ "stencil spec synthesis")
+  <> (command "units-suggest" . info cmdUnitsSuggest
+       . progDesc $ "suggest variables to annotate with units-of-measure for maximum coverage")
+  <> (command "units-check" . info cmdUnitsCheck
+       . progDesc $ "unit-of-measure checking")
+  <> (command "units-infer" . info cmdUnitsInfer
+       . progDesc $ "unit-of-measure inference")
+  <> (command "units-synth" . info cmdUnitsSynth
+       . progDesc $ "unit-of-measure synthesise specs")
+  <> (command "units-compile" . info cmdUnitsCompile
+       . progDesc $ "units-of-measure compile module information")
+  <> commandGroup "Analysis Commands"
+
+
+refactoringsParser :: Parser Command
+refactoringsParser = hsubparser $
+     (command "common" . info cmdRefactCommon
+       . progDesc $ "common block elimination")
+  <> (command "equivalence" . info cmdRefactEquivalence
+       . progDesc $ "equivalence elimination")
+  <> (command "dead" . info cmdRefactDead
+       . progDesc $ "dead-code elimination")
+  <> (command "datatype" . info cmdRefactDatatype
+       . progDesc $ "derived data type introduction")
+  <> commandGroup "Refactoring Commands"
+
+
+topLevelCommands :: Parser Command
+topLevelCommands = versionOption
+  where versionOption = pure CmdTopVersion <* switch
+                        (  long "version"
+                        <> short 'v'
+                        <> short '?'
+                        <> help "show version number")
+
+
+-- | Collective parser for all CamFort commands.
+commandParser :: Parser Command
+commandParser =
+  helper <*> (analysesParser <|> refactoringsParser <|> topLevelCommands)
+
+
+main :: IO ()
+main = do
+  cmd <- execParser (info commandParser idm)
+  runCommand cmd
+  where
+    getExcludes = fromMaybe [] . exclude
+    getOutputFile _ (WriteFile f) = f
+    getOutputFile inp WriteInplace = inp
+    runCommand (CmdAST ro) =
+      ast (inputSource ro) (getExcludes ro)
+    runCommand (CmdCount ro) =
+      countVarDecls (inputSource ro) (getExcludes ro)
+    runCommand (CmdStencilsCheck ro) =
+      stencilsCheck (inputSource ro) (getExcludes ro)
+    runCommand (CmdStencilsInfer so) =
+      let ro = soReadOptions so
+          wo = soWriteOptions so
+          inFile = inputSource ro
+      in stencilsInfer inFile (getExcludes ro)
+                       (getOutputFile inFile wo) (soInferMode so)
+    runCommand (CmdStencilsSynth sso) =
+      let so = ssoStencilsOptions sso
+          ro = soReadOptions so
+          wo = soWriteOptions so
+          ao = ssoAnnotationOptions sso
+          inFile = inputSource ro
+      in stencilsSynth inFile (getExcludes ro)
+                       (getOutputFile inFile wo) (soInferMode so)
+                       (annotationType ao)
+    runCommand (CmdUnitsSuggest uwo) =
+      let uo = uwoUnitsOptions uwo
+          ro = uoReadOptions uo
+          wo = uwoWriteOptions uwo
+          inFile = inputSource ro
+      in unitsCriticals inFile (getExcludes ro)
+                       (getOutputFile inFile wo)
+                       (literals uo) (debug uo)
+                       (includeDir uo)
+    runCommand (CmdUnitsCheck uo) =
+      let ro = uoReadOptions uo
+          inFile = inputSource ro
+      in unitsCheck inFile (getExcludes ro)
+                       (literals uo) (debug uo)
+                       (includeDir uo)
+    runCommand (CmdUnitsInfer uo) =
+      let ro = uoReadOptions uo
+          inFile = inputSource ro
+      in unitsInfer inFile (getExcludes ro)
+                       (literals uo) (debug uo)
+                       (includeDir uo)
+    runCommand (CmdUnitsSynth uso) =
+      let uwo = usoUnitsWriteOptions uso
+          uo = uwoUnitsOptions uwo
+          ro = uoReadOptions uo
+          wo = uwoWriteOptions uwo
+          ao = usoAnnotationOptions uso
+          inFile = inputSource ro
+      in unitsSynth inFile (getExcludes ro)
+                       (getOutputFile inFile wo)
+                       (annotationType ao)
+                       (literals uo) (debug uo)
+                       (includeDir uo)
+    runCommand (CmdUnitsCompile uwo) =
+      let uo = uwoUnitsOptions uwo
+          ro = uoReadOptions uo
+          wo = uwoWriteOptions uwo
+          inFile = inputSource ro
+      in unitsCompile inFile (getExcludes ro)
+                       (getOutputFile inFile wo)
+                       (literals uo) (debug uo)
+                       (includeDir uo)
+    runCommand (CmdRefactCommon rfo) =
+      let ro = rfoReadOptions rfo
+          wo = rfoWriteOptions rfo
+          inFile = inputSource ro
+      in common inFile (getExcludes ro) (getOutputFile inFile wo)
+    runCommand (CmdRefactDead rfo) =
+      let ro = rfoReadOptions rfo
+          wo = rfoWriteOptions rfo
+          inFile = inputSource ro
+      in dead inFile (getExcludes ro) (getOutputFile inFile wo)
+    runCommand (CmdRefactEquivalence rfo) =
+      let ro = rfoReadOptions rfo
+          wo = rfoWriteOptions rfo
+          inFile = inputSource ro
+      in equivalences inFile (getExcludes ro) (getOutputFile inFile wo)
+    runCommand (CmdRefactDatatype rfo) =
+      let ro = rfoReadOptions rfo
+          wo = rfoWriteOptions rfo
+          inFile = inputSource ro
+      in datatypes inFile (getExcludes ro) (getOutputFile inFile wo)
+    runCommand CmdTopVersion = displayVersion
 
 
 -- | Current CamFort version.
@@ -263,25 +410,3 @@ versionMessage = "CamFort " ++ version ++ " - Cambridge Fortran Infrastructure."
 -- | Print the full version string.
 displayVersion :: IO ()
 displayVersion = putStrLn versionMessage
-
-
--- | Print the help message.
-displayHelp :: IO ()
-displayHelp = putStrLn fullUsageInfo
-
-
--- | One-line usage string.
-usage = "Usage: camfort <MODE> <INPUT> [OUTPUT] [OPTIONS...]\n"
-
-
--- | Description of supported CamFort functions for user display.
-menu =
-  "Refactor functions:\n"
-  ++ concatMap display refactorings
-  ++ "\nAnalysis functions:\n"
-  ++ concatMap display analyses
-  where
-    space = replicate 5 ' '
-    display f = space ++ commandName f ++
-                replicate (15 - length (commandName f)) ' ' ++
-                "   [" ++ info f ++ "] \n"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -28,10 +28,9 @@ import Camfort.Functionality
 import Data.Text (pack, unpack, split)
 
 
-
-
-{-| The entry point to CamFort. Displays user information, and
-    handlers which functionality is being requested -}
+-- | The entry point to CamFort. Displays user information, and
+-- | handles which functionality is being requested
+main :: IO ()
 main = do
   args <- getArgs
   (opts,posArgs) <- compilerOpts args
@@ -75,11 +74,9 @@ main = do
         else putStrLn fullUsageInfo
 
 
-
-
--- * Options for CamFort and information on the different modes
-
+-- | Usage information, including descriptions of supported functions.
 fullUsageInfo = usageInfo (usage ++ menu ++ "\nOptions:") options
+
 
 options :: [OptDescr Flag]
 options =
@@ -106,6 +103,9 @@ options =
          "synthesise annotations compatible with Ford"
      ]
 
+
+-- | Wrapper around 'getOpt' to provide usage information
+-- upon failure.
 compilerOpts :: [String] -> IO ([Flag], [String])
 compilerOpts argv =
   case getOpt Permute options argv of
@@ -114,23 +114,24 @@ compilerOpts argv =
   where helpPrompt = "Try camfort --help for more information."
 
 
-
-
--- | Datatype for a functionality provided by the system, i.e. this is the
+-- | Functionality provided by the system, i.e. this is the
 -- wiring between the outward facing command line interface and our internal
--- functions
+-- functions.
 data Functionality = Functionality
-  { commandName :: String          -- ^ the command invoked by user at the cli
-  , altNames :: [String]           -- ^ alternative command names (let's be nice)
-  , fun :: FileOrDir -> [Filename] -> FileOrDir -> Options -> IO () -- ^ the function to dispatch to
-  , info :: String                 -- ^ information about the functionality
-  , outputFileReq :: OutputFileReq -- ^ whether an output file is required
+  { commandName   :: String         -- ^ Command invoked by user at the cli
+  , altNames      :: [String]       -- ^ Alternative command names
+                                    -- ^ Function to dispatch to
+  , fun           :: FileOrDir -> [Filename] -> FileOrDir -> Options -> IO ()
+  , info          :: String         -- ^ Description of functionality
+  , outputFileReq :: OutputFileReq  -- ^ Whether an output file is required
   }
 
--- | A tag do destinguish whether a functionality requires an output file
+
+-- | Tag to distinguish whether a functionality requires an output file.
 data OutputFileReq = OutputFileReq | OutputFileNotReq
 
--- | Given a string, maybe return an associated Functionality
+
+-- | Resolve some text into CamFort functionality.
 lookupFunctionality :: String -> [Functionality] -> Maybe Functionality
 lookupFunctionality str = find (getFunctionality str)
   where getFunctionality s f | commandName f == s  = True
@@ -138,11 +139,13 @@ lookupFunctionality str = find (getFunctionality str)
                              | otherwise           = False
 
 
-
--- | The list of functionalties that Camfort provides
+-- | The functionalties that Camfort provides
 functionalities :: [Functionality]
 functionalities = analyses ++ refactorings
 
+
+-- | Functionality for analysis.
+analyses :: [Functionality]
 analyses =
   [ Functionality
       "count"
@@ -215,6 +218,9 @@ analyses =
       OutputFileReq
   ]
 
+
+-- | Functionality for refactoring.
+refactorings :: [Functionality]
 refactorings =
   [ Functionality
       "common"
@@ -246,18 +252,29 @@ refactorings =
   ]
 
 
-
--- * Usage and about information
+-- | Current CamFort version.
 version = "0.903"
+
+
+-- | Full CamFort version string.
 versionMessage = "CamFort " ++ version ++ " - Cambridge Fortran Infrastructure."
 
+
+-- | Print the full version string.
 displayVersion :: IO ()
 displayVersion = putStrLn versionMessage
 
+
+-- | Print the help message.
 displayHelp :: IO ()
 displayHelp = putStrLn fullUsageInfo
 
+
+-- | One-line usage string.
 usage = "Usage: camfort <MODE> <INPUT> [OUTPUT] [OPTIONS...]\n"
+
+
+-- | Description of supported CamFort functions for user display.
 menu =
   "Refactor functions:\n"
   ++ concatMap display refactorings

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -149,7 +149,7 @@ readOptions = liftA ReadOptions
 writeOptions :: Parser WriteOptions
 writeOptions = (liftA WriteFile . fileArgument $
                  help "file to write output to")
-               <|> (pure WriteInplace <* switch
+               <|> (pure WriteInplace <* flag' True
                      (   long "inplace"
                       <> help "write in place (replaces input files)"))
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -38,6 +38,7 @@ main = do
   (opts,posArgs) <- compilerOpts args
   case opts of
     (Version:_) -> displayVersion
+    (Help:_)    -> displayHelp
     _           -> do
       if length args >= 2 then
         let (f : (inp : _)) = args
@@ -85,6 +86,8 @@ options :: [OptDescr Flag]
 options =
      [ Option ['v','?'] ["version"] (NoArg Version)
          "show version number"
+     , Option [] ["help"] (NoArg Help)
+         "show this help message and exit"
      , Option [] ["inplace"] (NoArg RefactorInPlace)
          "refactor in place (replaces input files)"
      , Option ['e'] ["exclude"] (ReqArg Excludes "FILES")
@@ -251,6 +254,9 @@ versionMessage = "CamFort " ++ version ++ " - Cambridge Fortran Infrastructure."
 
 displayVersion :: IO ()
 displayVersion = putStrLn versionMessage
+
+displayHelp :: IO ()
+displayHelp = putStrLn fullUsageInfo
 
 usage = "Usage: camfort <MODE> <INPUT> [OUTPUT] [OPTIONS...]\n"
 menu =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -34,7 +34,6 @@ import Data.Text (pack, unpack, split)
     handlers which functionality is being requested -}
 main = do
   args <- getArgs
-  putStrLn ""
   (opts,posArgs) <- compilerOpts args
   case opts of
     (Version:_) -> displayVersion

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -111,8 +111,8 @@ compilerOpts :: [String] -> IO ([Flag], [String])
 compilerOpts argv =
   case getOpt Permute options argv of
     (o,n,[]  ) -> return (o,n)
-    (_,_,errs) -> ioError (userError (concat errs ++ usageInfo header options))
-  where header = versionMessage ++ usage ++ menu ++ "\nOptions:"
+    (_,_,errs) -> ioError (userError (concat errs ++ helpPrompt))
+  where helpPrompt = "Try camfort --help for more information."
 
 
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -141,7 +141,7 @@ excludeOption = optional $ multiFileOption $
 
 -- | Parse options for 'ReadOptions'.
 readOptions :: Parser ReadOptions
-readOptions = liftA ReadOptions
+readOptions = fmap ReadOptions
   (fileArgument $ help "input file")
   <*> excludeOption
 
@@ -149,7 +149,7 @@ readOptions = liftA ReadOptions
 -- | User must specify either an ouput file, or say that the file
 -- | should be rewritten in place.
 writeOptions :: Parser WriteOptions
-writeOptions = (liftA WriteFile . fileArgument $
+writeOptions = (fmap WriteFile . fileArgument $
                  help "file to write output to")
                <|> (pure WriteInplace <* flag' ()
                      (   long "inplace"
@@ -157,7 +157,7 @@ writeOptions = (liftA WriteFile . fileArgument $
 
 
 stencilsOptions :: Parser StencilsOptions
-stencilsOptions = liftA StencilsOptions
+stencilsOptions = fmap StencilsOptions
   readOptions <*> writeOptions <*> inferModeOption
   where
     inferModeOption = fmap (fromMaybe defaultValue)
@@ -176,12 +176,12 @@ stencilsOptions = liftA StencilsOptions
 
 
 stencilsSynthOptions :: Parser StencilsSynthOptions
-stencilsSynthOptions = liftA StencilsSynthOptions
+stencilsSynthOptions = fmap StencilsSynthOptions
   stencilsOptions <*> annotationOptions
 
 
 unitsOptions :: Parser UnitsOptions
-unitsOptions = liftA UnitsOptions
+unitsOptions = fmap UnitsOptions
       readOptions
   <*> literalsOption
   <*> debugOption
@@ -204,12 +204,12 @@ unitsOptions = liftA UnitsOptions
 
 
 unitsWriteOptions :: Parser UnitsWriteOptions
-unitsWriteOptions = liftA UnitsWriteOptions
+unitsWriteOptions = fmap UnitsWriteOptions
   unitsOptions <*> writeOptions
 
 
 annotationOptions :: Parser AnnotationOptions
-annotationOptions = liftA AnnotationOptions $
+annotationOptions = fmap AnnotationOptions $
   flag ATDefault Doxygen
     (long "doxygen" <> help "synthesise annotations compatible with Doxygen")
   <|> flag ATDefault Ford
@@ -217,41 +217,41 @@ annotationOptions = liftA AnnotationOptions $
 
 
 unitsSynthOptions :: Parser UnitsSynthOptions
-unitsSynthOptions = liftA UnitsSynthOptions
+unitsSynthOptions = fmap UnitsSynthOptions
   unitsWriteOptions <*> annotationOptions
 
 
 refactOptions :: Parser RefactOptions
-refactOptions = liftA RefactOptions
+refactOptions = fmap RefactOptions
   readOptions <*> writeOptions
 
 
 cmdCount, cmdAST :: Parser Command
-cmdCount = liftA CmdCount readOptions
-cmdAST   = liftA CmdAST   readOptions
+cmdCount = fmap CmdCount readOptions
+cmdAST   = fmap CmdAST   readOptions
 
 
 cmdStencilsCheck, cmdStencilsInfer, cmdStencilsSynth :: Parser Command
-cmdStencilsCheck = liftA CmdStencilsCheck readOptions
-cmdStencilsInfer = liftA CmdStencilsInfer stencilsOptions
-cmdStencilsSynth = liftA CmdStencilsSynth stencilsSynthOptions
+cmdStencilsCheck = fmap CmdStencilsCheck readOptions
+cmdStencilsInfer = fmap CmdStencilsInfer stencilsOptions
+cmdStencilsSynth = fmap CmdStencilsSynth stencilsSynthOptions
 
 
 cmdUnitsSuggest, cmdUnitsCheck, cmdUnitsInfer
   , cmdUnitsSynth, cmdUnitsCompile :: Parser Command
-cmdUnitsSuggest = liftA CmdUnitsSuggest unitsWriteOptions
-cmdUnitsCheck   = liftA CmdUnitsCheck   unitsOptions
-cmdUnitsInfer   = liftA CmdUnitsInfer   unitsOptions
-cmdUnitsSynth   = liftA CmdUnitsSynth   unitsSynthOptions
-cmdUnitsCompile = liftA CmdUnitsCompile unitsWriteOptions
+cmdUnitsSuggest = fmap CmdUnitsSuggest unitsWriteOptions
+cmdUnitsCheck   = fmap CmdUnitsCheck   unitsOptions
+cmdUnitsInfer   = fmap CmdUnitsInfer   unitsOptions
+cmdUnitsSynth   = fmap CmdUnitsSynth   unitsSynthOptions
+cmdUnitsCompile = fmap CmdUnitsCompile unitsWriteOptions
 
 
 cmdRefactCommon, cmdRefactDatatype
   , cmdRefactDead, cmdRefactEquivalence :: Parser Command
-cmdRefactCommon      = liftA CmdRefactCommon refactOptions
-cmdRefactDatatype    = liftA CmdRefactDatatype refactOptions
-cmdRefactDead        = liftA CmdRefactDead refactOptions
-cmdRefactEquivalence = liftA CmdRefactEquivalence refactOptions
+cmdRefactCommon      = fmap CmdRefactCommon refactOptions
+cmdRefactDatatype    = fmap CmdRefactDatatype refactOptions
+cmdRefactDead        = fmap CmdRefactDead refactOptions
+cmdRefactEquivalence = fmap CmdRefactEquivalence refactOptions
 
 
 analysesParser :: Parser Command

--- a/tests/Camfort/ReprintSpec.hs
+++ b/tests/Camfort/ReprintSpec.hs
@@ -5,6 +5,7 @@ module Camfort.ReprintSpec (spec) where
 import Camfort.Functionality
 import Camfort.Reprint
 import Camfort.Helpers
+import Camfort.Specification.Units.Monad (LiteralsOpt(LitMixed))
 import qualified Data.ByteString.Char8 as B
 import qualified Language.Fortran.Util.Position as FU
 
@@ -72,7 +73,8 @@ spec =
 
     context "Integration test with synthesising a spec" $ do
        runIO $ unitsSynth ("tests" </> "fixtures" </> "simple.f90") []
-                          ("tests" </> "fixtures" </> "simple.f90.out") []
+                          ("tests" </> "fixtures" </> "simple.f90.out")
+         ATDefault LitMixed False Nothing
        actual <- runIO $ readFile ("tests" </> "fixtures" </> "simple.f90.out")
        expected <- runIO $ readFile ("tests" </> "fixtures" </> "simple.expected.f90")
        it "Unit synth" $ actual `shouldBe` expected

--- a/tests/Camfort/ReprintSpec.hs
+++ b/tests/Camfort/ReprintSpec.hs
@@ -73,8 +73,8 @@ spec =
 
     context "Integration test with synthesising a spec" $ do
        runIO $ unitsSynth ("tests" </> "fixtures" </> "simple.f90") []
-                          ("tests" </> "fixtures" </> "simple.f90.out")
-         ATDefault LitMixed False Nothing
+         LitMixed False Nothing
+         ("tests" </> "fixtures" </> "simple.f90.out") ATDefault
        actual <- runIO $ readFile ("tests" </> "fixtures" </> "simple.f90.out")
        expected <- runIO $ readFile ("tests" </> "fixtures" </> "simple.expected.f90")
        it "Unit synth" $ actual `shouldBe` expected

--- a/tests/Camfort/Transformation/CommonSpec.hs
+++ b/tests/Camfort/Transformation/CommonSpec.hs
@@ -30,7 +30,7 @@ spec =
       expectedMod <- runIO $ readSample "cmn.expected.f90"
 
       let outFile = samplesBase </> "common.f90.out"
-      runIO $ common (samplesBase </> "common.f90") [] outFile ()
+      runIO $ common (samplesBase </> "common.f90") [] outFile
 
       actual    <- runIO $ readSample "common.f90.out"
       actualMod <- runIO $ readSample "cmn.f90"

--- a/tests/Camfort/Transformation/EquivalenceElimSpec.hs
+++ b/tests/Camfort/Transformation/EquivalenceElimSpec.hs
@@ -40,7 +40,7 @@ readActual :: FilePath -> IO String
 readActual argumentFilename = do
   let argumentPath = samplesBase </> argumentFilename
   let outFile = argumentPath `addExtension` "out"
-  equivalences argumentPath [] outFile ()
+  equivalences argumentPath [] outFile
   actual <- readFile outFile
   removeFile outFile
   return actual


### PR DESCRIPTION
## To Do

- [ ] Separate functionality of `Main.hs`
- [ ] Simplify `Camfort.Functionality.hs`
- [ ] Set up automatic installation of tab completion


## Changes

### Tab Completion

For the moment, to get tab completion working run `stack install && source <(camfort --bash-completion-script=$(which camfort)` in the `camfort` directory.