### PR TITLE
Ensure Grammar does not accept invalid stencils

### DIFF
--- a/src/Camfort/Specification/Stencils/CheckBackend.hs
+++ b/src/Camfort/Specification/Stencils/CheckBackend.hs
@@ -70,6 +70,7 @@ instance SynToAst SYN.Region RegionSum where
 -- Convert a grammar syntax to Disjunctive Normal Form AST
 dnf :: (?renv :: RegionEnv) => SYN.Region -> Either ErrorMsg RegionSum
 
+dnf (SYN.RegionConst rconst) = pure . Sum $ [Product [rconst]]
 -- Distributive law
 dnf (SYN.And r1 r2) = do
     r1' <- dnf r1
@@ -83,10 +84,7 @@ dnf (SYN.Or r1 r2) = do
     r2' <- dnf r2
     return $ Sum $ unSum r1' ++ unSum r2'
 -- Region conversion
-dnf (SYN.Forward dep dim reflx)  = return $ Sum [Product [Forward dep dim reflx]]
-dnf (SYN.Backward dep dim reflx) = return $ Sum [Product [Backward dep dim reflx]]
-dnf (SYN.Centered dep dim reflx) = return $ Sum [Product [Centered dep dim reflx]]
-dnf (SYN.Var v)            =
+dnf (SYN.Var v)              =
     case lookup v ?renv of
       Nothing -> Left $ "Error: region " ++ v ++ " is not in scope."
       Just rs -> return rs

--- a/src/Camfort/Specification/Stencils/Syntax.hs
+++ b/src/Camfort/Specification/Stencils/Syntax.hs
@@ -240,11 +240,12 @@ instance {-# OVERLAPS #-} Show (Multiplicity (Approximation Spatial)) where
         case appr of
           Exact s -> linearity ++ optionalSeparator sep (show s)
           Bound Nothing Nothing -> "empty"
-          Bound Nothing (Just s) -> "atMost, " ++ linearity ++ optionalSeparator sep (show s)
-          Bound (Just s) Nothing -> "atLeast, " ++ linearity ++ optionalSeparator sep (show s)
+          Bound Nothing (Just s) -> linearity ++ optionalSeparator sep "atMost, " ++ show s
+          Bound (Just s) Nothing -> linearity ++ optionalSeparator sep "atLeast, " ++ show s
           Bound (Just sL) (Just sU) ->
-            "atLeast, " ++ linearity ++ optionalSeparator sep (show sL) ++
-            "; atMost, " ++ linearity ++ optionalSeparator sep (show sU)
+            concat [ linearity, optionalSeparator sep (show sL), ";"
+                   , if linearity == empty then "" else " " ++ linearity ++ ", "
+                   , "atMost, ", show sU ]
       optionalSeparator _   "" = ""
       optionalSeparator sep s  = sep ++ s
 

--- a/tests/Camfort/Specification/Stencils/CheckSpec.hs
+++ b/tests/Camfort/Specification/Stencils/CheckSpec.hs
@@ -55,7 +55,7 @@ spec =
                       (Sum [Product [Backward 2 1 True]])) Nothing)])
 
       it "parse and convert stencil requiring distribution (5)" $
-          parseAndConvert "= stencil atleast, readonce, (forward(depth=1, dim=1) * ((centered(depth=1, dim=2)) + backward(depth=3, dim=4))) :: frob"
+          parseAndConvert "= stencil readonce, atleast, (forward(depth=1, dim=1) * ((centered(depth=1, dim=2)) + backward(depth=3, dim=4))) :: frob"
           `shouldBe`
             (Right $ Right [(["frob"], Specification $
              Once $ Bound (Just $ Spatial

--- a/tests/Camfort/Specification/Stencils/GrammarSpec.hs
+++ b/tests/Camfort/Specification/Stencils/GrammarSpec.hs
@@ -6,6 +6,7 @@ import Camfort.Specification.Stencils.Grammar
 import Camfort.Specification.Stencils.Model (
     Approximation(..)
   , Multiplicity(..))
+import qualified Camfort.Specification.Stencils.Syntax as Syn
 
 import Test.Hspec hiding (Spec)
 import qualified Test.Hspec as Test
@@ -71,20 +72,24 @@ spec =
         Right (SpecDec (Spec . Once . Exact $ Or (Var "r1") (Var "r2")) ["a"])
 
 
+    let regionTestCase isRefl =
+          Right (RegionDec "r"
+                  (Or (RegionConst (Syn.Forward 1 1 isRefl))
+                   (RegionConst (Syn.Backward 2 2 isRefl))))
     it "region defn" $
       parse "= region :: r = forward(depth=1, dim=1) + backward(depth=2, dim=2)"
       `shouldBe`
-        Right (RegionDec "r" (Or (Forward 1 1 True) (Backward 2 2 True)))
+        regionTestCase True
 
     it "region defn syntactic permutation" $
       parse "= region :: r = forward(dim=1,depth=1) + backward(depth=2, dim=2)"
       `shouldBe`
-        Right (RegionDec "r" (Or (Forward 1 1 True) (Backward 2 2 True)))
+        regionTestCase True
 
     it "region defn irreflx syntactic permutation" $
       parse "= region :: r = forward(nonpointed,dim=1,depth=1) + backward(depth=2,nonpointed,dim=2)"
       `shouldBe`
-        Right (RegionDec "r" (Or (Forward 1 1 False) (Backward 2 2 False)))
+        regionTestCase False
 
 
 parse = specParser

--- a/tests/Camfort/Specification/Stencils/GrammarSpec.hs
+++ b/tests/Camfort/Specification/Stencils/GrammarSpec.hs
@@ -1,9 +1,23 @@
 module Camfort.Specification.Stencils.GrammarSpec (spec) where
 
+import Data.Either (isLeft)
+
 import Camfort.Specification.Stencils.Grammar
+import Camfort.Specification.Stencils.Model (
+    Approximation(..)
+  , Multiplicity(..))
 
 import Test.Hspec hiding (Spec)
 import qualified Test.Hspec as Test
+
+modifierTest :: String -> (Region -> Multiplicity (Approximation Region)) -> SpecWith ()
+modifierTest modifiers f =
+  it ("modified with " ++ modifiers) $ parse ("= stencil " ++ modifiers ++ " r1 + r2 :: a")
+  `shouldBe` Right (SpecDec (Spec (f $ Or (Var "r1") (Var "r2"))) ["a"])
+
+invalidStencilTest :: String -> String -> SpecWith ()
+invalidStencilTest description stencilString =
+  it description $ parse stencilString `shouldSatisfy` isLeft
 
 spec :: Test.Spec
 spec =
@@ -11,7 +25,30 @@ spec =
     it "basic unmodified stencil" $
       parse "= stencil r1 + r2 :: a"
       `shouldBe`
-        Right (SpecDec (Spatial [] (Or (Var "r1") (Var "r2"))) ["a"])
+        Right (SpecDec (Spec . Mult . Exact $ Or (Var "r1") (Var "r2")) ["a"])
+
+    context "with modifiers" $ do
+      modifierTest "readOnce,"          (Once . Exact)
+      modifierTest "atLeast,"           (Mult . (`Bound` Nothing) . Just)
+      modifierTest "atMost,"            (Mult . Bound Nothing . Just)
+      modifierTest "readOnce, atLeast," (Once . (`Bound` Nothing) . Just)
+      modifierTest "readOnce, atMost,"  (Once . Bound Nothing . Just)
+
+    describe "modifiers are case insensitive" $ do
+      modifierTest "readOnce, atLeast," (Once . (`Bound` Nothing) . Just)
+      modifierTest "readOnce, atMost,"  (Once . Bound Nothing . Just)
+      modifierTest "readonce, atleast," (Once . (`Bound` Nothing) . Just)
+      modifierTest "readonce, atmost,"  (Once . Bound Nothing . Just)
+
+    describe "invalid stencils" $ do
+      invalidStencilTest "approximation before multiplicity"
+        "= stencil atLeast, readOnce r1 :: a"
+      invalidStencilTest "repeated multiplicities"
+        "= stencil readOnce, readOnce r1 :: a"
+      invalidStencilTest "repeated approximations"
+        "= stencil atLeast, atLeast, r1 :: a"
+      invalidStencilTest "multiple approximations"
+        "= stencil atLeast, atMost, r1 :: a"
 
 {- Should no longer be possible
     it "just pointed stencil" $
@@ -24,7 +61,7 @@ spec =
     it "basic modified stencil (1)" $
       parse "      = stencil readonce, r1 + r2 :: a"
       `shouldBe`
-        Right (SpecDec (Spatial [ReadOnce] (Or (Var "r1") (Var "r2"))) ["a"])
+        Right (SpecDec (Spec . Once . Exact $ Or (Var "r1") (Var "r2")) ["a"])
 
 {- Should no longer be possible
     it "basic monfieid stencil (2)" $

--- a/tests/Camfort/Specification/Stencils/GrammarSpec.hs
+++ b/tests/Camfort/Specification/Stencils/GrammarSpec.hs
@@ -49,34 +49,27 @@ spec =
         "= stencil atLeast, atLeast, r1 :: a"
       invalidStencilTest "multiple approximations"
         "= stencil atLeast, atMost, r1 :: a"
-
-{- Should no longer be possible
-    it "just pointed stencil" $
-      parse "= stencil pointed(dims=1,2) :: a"
-      `shouldBe`
-        Right (SpecDec (Spatial [Pointed [1, 2]] Nothing) ["a"])
--}
-
+      invalidStencilTest "just pointed stencil"
+        "= stencil pointed(dims=1,2) :: a"
+      invalidStencilTest "basic monfieid stencil (2)"
+        "= stencil atleast, pointed(dims=1,2), \
+             \       forward(depth=1, dim=1) :: x"
+      invalidStencilTest "basic stencil with pointed and nonpointed"
+        "= stencil atleast, pointed(dims=2),  \
+            \        nonpointed(dims=1), forward(depth=1, dim=1) :: frob"
+      invalidStencilTest "complex stencil"
+        "= stencil atleast, pointed(dims=1,2), readonce, \
+            \ (forward(depth=1, dim=1) + r) * backward(depth=3, dim=4) \
+            \ :: frob"
+      invalidStencilTest "pointed/nonpointed on same dim"
+        "= stencil atleast, nonpointed(dims=2), pointed(dims=1,2), \
+             \ forward(depth=1, dim=1) :: x"
 
     it "basic modified stencil (1)" $
       parse "      = stencil readonce, r1 + r2 :: a"
       `shouldBe`
         Right (SpecDec (Spec . Once . Exact $ Or (Var "r1") (Var "r2")) ["a"])
 
-{- Should no longer be possible
-    it "basic monfieid stencil (2)" $
-      parse "= stencil atleast, pointed(dims=1,2), \
-             \       forward(depth=1, dim=1) :: x"
-      `shouldBe`
-        Right (SpecDec (Spatial [AtLeast,Pointed [1,2]] (Just $ Forward 1 1)) ["x"])
-
-    it "basic stencil with pointed and nonpointed" $
-      parse "= stencil atleast, pointed(dims=2),  \
-            \        nonpointed(dims=1), forward(depth=1, dim=1) :: frob"
-      `shouldBe`
-        Right (SpecDec (Spatial [AtLeast, Nonpointed [1], Pointed [2]]
-                               (Just $ Forward 1 1)) ["frob"])
--}
 
     it "region defn" $
       parse "= region :: r = forward(depth=1, dim=1) + backward(depth=2, dim=2)"
@@ -92,31 +85,6 @@ spec =
       parse "= region :: r = forward(nonpointed,dim=1,depth=1) + backward(depth=2,nonpointed,dim=2)"
       `shouldBe`
         Right (RegionDec "r" (Or (Forward 1 1 False) (Backward 2 2 False)))
-
-{- Should no longer be possible
-    it "complex stencil" $
-      parse "= stencil atleast, pointed(dims=1,2), readonce, \
-            \ (forward(depth=1, dim=1) + r) * backward(depth=3, dim=4) \
-            \ :: frob"
-      `shouldBe`
-       Right (SpecDec (Spatial [AtLeast,ReadOnce,Pointed [1,2]]
-             (Just $ And (Or (Forward 1 1) (Var "r")) (Backward 3 4))) ["frob"])
-
-    it "invalid stencil (atLeast/atMost)" $
-      parse "= stencil atleast, atmost, pointed(dims=1,2), \
-             \       forward(depth=1, dim=1) :: x"
-      `shouldBe`
-        (Left $ ProbablyAnnotation $
-          "Conflicting modifiers: cannot use 'atLeast' and 'atMost' together")
-
-    it "invalid stencil (pointed/nonpointed on same dim)" $
-      parse "= stencil atleast, nonpointed(dims=2), pointed(dims=1,2), \
-             \ forward(depth=1, dim=1) :: x"
-      `shouldBe`
-        (Left $ ProbablyAnnotation $
-              "Conflicting modifiers: stencil marked as both\
-              \ nonpointed and pointed in dimensions = 2")
--}
 
 
 parse = specParser

--- a/tests/fixtures/Specification/Stencils/example5.expected.f
+++ b/tests/fixtures/Specification/Stencils/example5.expected.f
@@ -6,8 +6,8 @@
       real a(0:imax)
 
       do i = 0, imax
-c= stencil atLeast, readOnce, (pointed(dim=1)) :: a
-c= stencil atMost, readOnce, (forward(depth=2, dim=1)) :: a
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
+c= stencil readOnce, atMost, (forward(depth=2, dim=1)) :: a
             a(i) = a(i) + a(i+2)
       end do
 

--- a/tests/fixtures/Specification/Stencils/example5.expected.f90
+++ b/tests/fixtures/Specification/Stencils/example5.expected.f90
@@ -6,8 +6,8 @@ program example5
   real a(0:imax)
 
   do i = 0, imax
-      != stencil atLeast, readOnce, (pointed(dim=1)) :: a
-      != stencil atMost, readOnce, (forward(depth=2, dim=1)) :: a
+      != stencil readOnce, atLeast, (pointed(dim=1)) :: a
+      != stencil readOnce, atMost, (forward(depth=2, dim=1)) :: a
       a(i) = a(i) + a(i+2)
   end do
 end program

--- a/tests/fixtures/Specification/Stencils/example6.expected.f
+++ b/tests/fixtures/Specification/Stencils/example6.expected.f
@@ -6,8 +6,8 @@
       real a(0:imax)
 
       do i = 0, imax
-c= stencil atLeast, readOnce, (pointed(dim=1)) :: a
-c= stencil atMost, readOnce, (forward(depth=2, dim=1)) :: a
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
+c= stencil readOnce, atMost, (forward(depth=2, dim=1)) :: a
             a(i) = a(i) + a(i+2)
       end do
 

--- a/tests/fixtures/Specification/Stencils/example6.f
+++ b/tests/fixtures/Specification/Stencils/example6.f
@@ -6,7 +6,7 @@
       real a(0:imax)
 
       do i = 0, imax
-c= stencil atLeast, readOnce, (pointed(dim=1)) :: a
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
             a(i) = a(i) + a(i+2)
       end do
 

--- a/tests/fixtures/Specification/Stencils/example7.expected.f
+++ b/tests/fixtures/Specification/Stencils/example7.expected.f
@@ -6,8 +6,8 @@
       real a(0:imax)
 
       do i = 0, imax
-c= stencil atLeast, readOnce, (pointed(dim=1)) :: a
-c= stencil atMost, readOnce, (forward(depth=2, dim=1)) :: a
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
+c= stencil readOnce, atMost, (forward(depth=2, dim=1)) :: a
             a(i) = a(i) + a(i+2)
       end do
 

--- a/tests/fixtures/Specification/Stencils/example7.f
+++ b/tests/fixtures/Specification/Stencils/example7.f
@@ -6,8 +6,8 @@
       real a(0:imax)
 
       do i = 0, imax
-c= stencil atLeast, readOnce, (pointed(dim=1)) :: a
-c= stencil atMost, readOnce, (forward(depth=2, dim=1)) :: a
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
+c= stencil readOnce, atMost, (forward(depth=2, dim=1)) :: a
             a(i) = a(i) + a(i+2)
       end do
 

--- a/tests/fixtures/Specification/Stencils/example8.expected.f
+++ b/tests/fixtures/Specification/Stencils/example8.expected.f
@@ -6,8 +6,8 @@
       real a(0:imax)
 
       do i = 0, imax
-c= stencil atMost, readOnce, (forward(depth=2, dim=1)) :: a
-c= stencil atLeast, readOnce, (pointed(dim=1)) :: a
+c= stencil readOnce, atMost, (forward(depth=2, dim=1)) :: a
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
             a(i) = a(i) + a(i+2)
       end do
 

--- a/tests/fixtures/Specification/Stencils/example8.f
+++ b/tests/fixtures/Specification/Stencils/example8.f
@@ -6,7 +6,7 @@
       real a(0:imax)
 
       do i = 0, imax
-c= stencil atMost, readOnce, (forward(depth=2, dim=1)) :: a
+c= stencil readOnce, atMost, (forward(depth=2, dim=1)) :: a
             a(i) = a(i) + a(i+2)
       end do
 


### PR DESCRIPTION
@dorchard This ensures we follow a stricter (discussed) syntax, as well as reducing duplication between `Grammar.y` and `Syntax.hs`.