### PR TITLE
Add command aliases

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -276,28 +276,28 @@ analysesParser = commandsParser "Analysis Commands" analysesCommands
           [],
           cmdAST,           "print the raw AST -- for development purposes")
       , ("stencils-check",
-          ["stencil-check"],
+          ["stencil-check", "check-stencils", "check-stencil"],
           cmdStencilsCheck, "stencil spec checking")
       , ("stencils-infer",
-          ["stencil-infer"],
+          ["stencil-infer", "infer-stencils", "infer-stencil"],
           cmdStencilsInfer, "stencil spec inference")
       , ("stencils-synth",
-          ["stencil-synth"],
+          ["stencil-synth", "synth-stencils", "synth-stencil"],
           cmdStencilsSynth, "stencil spec synthesis")
       , ("units-suggest",
-          ["unit-suggest"],
+          ["unit-suggest", "suggest-units", "suggest-unit"],
           cmdUnitsSuggest,  "suggest variables to annotate with units-of-measure for maximum coverage")
       , ("units-check",
-          ["unit-check"],
+          ["unit-check", "check-units", "check-unit"],
           cmdUnitsCheck,    "unit-of-measure checking")
       , ("units-infer",
-          ["unit-infer"],
+          ["unit-infer", "infer-units", "infer-unit"],
           cmdUnitsInfer,    "unit-of-measure inference")
       , ("units-synth",
-          ["unit-synth"],
+          ["unit-synth", "synth-units", "synth-unit"],
           cmdUnitsSynth,    "unit-of-measure synthesise specs")
       , ("units-compile",
-          ["unit-compile"],
+          ["unit-compile", "compile-units", "compile-unit"],
           cmdUnitsCompile,  "units-of-measure compile module information") ]
 
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -243,41 +243,35 @@ cmdRefactCommon      = fmap CmdRefactCommon refactOptions
 cmdRefactDead        = fmap CmdRefactDead refactOptions
 cmdRefactEquivalence = fmap CmdRefactEquivalence refactOptions
 
+-- | Helper for building a parser for a group of commands.
+commandsParser :: String -> [(String, Parser Command, String)] -> Parser Command
+commandsParser groupName commands = hsubparser $
+  mconcat (fmap (\(cname, cfun, desc) -> command cname . info cfun . progDesc $ desc) commands)
+  <> commandGroup groupName
 
 analysesParser :: Parser Command
-analysesParser = hsubparser $
-     (command "count" . info cmdCount
-       . progDesc $ "count variable declarations")
-  <> (command "ast" . info cmdAST
-       . progDesc $ "print the raw AST -- for development purposes")
-  <> (command "stencils-check" . info cmdStencilsCheck
-       . progDesc $ "stencil spec checking")
-  <> (command "stencils-infer" . info cmdStencilsInfer
-       . progDesc $ "stencil spec inference")
-  <> (command "stencils-synth" . info cmdStencilsSynth
-       . progDesc $ "stencil spec synthesis")
-  <> (command "units-suggest" . info cmdUnitsSuggest
-       . progDesc $ "suggest variables to annotate with units-of-measure for maximum coverage")
-  <> (command "units-check" . info cmdUnitsCheck
-       . progDesc $ "unit-of-measure checking")
-  <> (command "units-infer" . info cmdUnitsInfer
-       . progDesc $ "unit-of-measure inference")
-  <> (command "units-synth" . info cmdUnitsSynth
-       . progDesc $ "unit-of-measure synthesise specs")
-  <> (command "units-compile" . info cmdUnitsCompile
-       . progDesc $ "units-of-measure compile module information")
-  <> commandGroup "Analysis Commands"
+analysesParser = commandsParser "Analysis Commands" analysesCommands
+  where
+    analysesCommands =
+      [ ("count",          cmdCount,         "count variable declarations")
+      , ("ast",            cmdAST,           "print the raw AST -- for development purposes")
+      , ("stencils-check", cmdStencilsCheck, "stencil spec checking")
+      , ("stencils-infer", cmdStencilsInfer, "stencil spec inference")
+      , ("stencils-synth", cmdStencilsSynth, "stencil spec synthesis")
+      , ("units-suggest",  cmdUnitsSuggest,  "suggest variables to annotate with units-of-measure for maximum coverage")
+      , ("units-check",    cmdUnitsCheck,    "unit-of-measure checking")
+      , ("units-infer",    cmdUnitsInfer,    "unit-of-measure inference")
+      , ("units-synth",    cmdUnitsSynth,    "unit-of-measure synthesise specs")
+      , ("units-compile",  cmdUnitsCompile,  "units-of-measure compile module information") ]
 
 
 refactoringsParser :: Parser Command
-refactoringsParser = hsubparser $
-     (command "common" . info cmdRefactCommon
-       . progDesc $ "common block elimination")
-  <> (command "equivalence" . info cmdRefactEquivalence
-       . progDesc $ "equivalence elimination")
-  <> (command "dead" . info cmdRefactDead
-       . progDesc $ "dead-code elimination")
-  <> commandGroup "Refactoring Commands"
+refactoringsParser = commandsParser "Refactoring Commands" refactoringsCommands
+  where
+    refactoringsCommands =
+      [ ("common",      cmdRefactCommon,      "common block elimination")
+      , ("equivalence", cmdRefactEquivalence, "equivalence elimination")
+      , ("dead",        cmdRefactDead,        "dead-code elimination") ]
 
 
 topLevelCommands :: Parser Command


### PR DESCRIPTION
This adds support for command aliases. Please note that aliases do _not_ show up in the help text, nor are they tab-completed.

Are there any other aliases you'd like added?


Fixes https://github.com/camfort/camfort/issues/68