### PR TITLE
Warn users with duplicate stencil specifications

### DIFF
--- a/tests/Camfort/Specification/StencilsSpec.hs
+++ b/tests/Camfort/Specification/StencilsSpec.hs
@@ -294,6 +294,14 @@ spec =
 \        but at (9:8)-(9:32) the code behaves as\n\
 \                stencil readOnce, (forward(depth=1, dim=1)) :: a\n\n\
 \Please resolve these errors, and then run synthesis again."
+      assertStencilSynthResponseOut "example14.f"
+        "warns when duplicate stencils exist, but continues"
+        "\nEncountered the following errors when checking stencil specs for 'tests/fixtures/Specification/Stencils/example14.f'\n\n\
+\(10:1)-(10:51)    Warning: Duplicate specification."
+      assertStencilSynthResponseOut "example15.f"
+        "warns when duplicate stencils exist (combined stencils), but continues"
+        "\nEncountered the following errors when checking stencil specs for 'tests/fixtures/Specification/Stencils/example15.f'\n\n\
+\(9:1)-(9:51)    Warning: Duplicate specification."
 
     sampleDirConts <- runIO $ listDirectory samplesDir
     expectedDirConts <- runIO $ listDirectory (samplesDir </> "expected")
@@ -330,6 +338,10 @@ spec =
               programSrc       <- runIO $ readFile file
               it testComment $ (fst $ synth AssignMode '=' (map (\(f, _, p) -> (f, p)) program))
                 `shouldBe` expectedResponse
+        assertStencilSynthResponseOut fileName testComment expectedResponse =
+          describe testComment $ do
+            assertStencilInferenceOnFile fileName "correct synthesis"
+            assertStencilSynthResponse fileName "correct output" expectedResponse
         fixturesDir = "tests" </> "fixtures" </> "Specification" </> "Stencils"
         samplesDir  = "samples" </> "stencils"
         getExpectedSrcFileName file =

--- a/tests/fixtures/Specification/Stencils/example14.expected.f
+++ b/tests/fixtures/Specification/Stencils/example14.expected.f
@@ -1,0 +1,15 @@
+      program example14
+      implicit none
+
+      integer i, imax
+      parameter (imax = 3)
+      real a(0:imax)
+
+      do i = 0, imax
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
+c= stencil readOnce, atMost, (forward(depth=2, dim=1)) :: a
+            a(i) = a(i) + a(i+2)
+      end do
+
+      end

--- a/tests/fixtures/Specification/Stencils/example14.f
+++ b/tests/fixtures/Specification/Stencils/example14.f
@@ -1,0 +1,14 @@
+      program example14
+      implicit none
+
+      integer i, imax
+      parameter (imax = 3)
+      real a(0:imax)
+
+      do i = 0, imax
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
+c= stencil readOnce, atLeast, (pointed(dim=1)) :: a
+            a(i) = a(i) + a(i+2)
+      end do
+
+      end

--- a/tests/fixtures/Specification/Stencils/example15.expected.f
+++ b/tests/fixtures/Specification/Stencils/example15.expected.f
@@ -1,0 +1,13 @@
+      program example15
+      implicit none
+
+      integer i
+      real a(0:10)
+
+      do i = 0, 10
+c= stencil readOnce, (forward(depth=1, dim=1)) :: a
+c= stencil readOnce, (forward(depth=1, dim=1)) :: a
+            a(i) = a(i) + a(i+1)
+      end do
+
+      end

--- a/tests/fixtures/Specification/Stencils/example15.f
+++ b/tests/fixtures/Specification/Stencils/example15.f
@@ -1,0 +1,13 @@
+      program example15
+      implicit none
+
+      integer i
+      real a(0:10)
+
+      do i = 0, 10
+c= stencil readOnce, (forward(depth=1, dim=1)) :: a
+c= stencil readOnce, (forward(depth=1, dim=1)) :: a
+            a(i) = a(i) + a(i+1)
+      end do
+
+      end


### PR DESCRIPTION
If a file contains duplicate stencil specifications for same code, then
warn the user when running stencils-check or synthesis.

Fixes #89.