### PR TITLE
Remove library files from executable section of Cabal file

### DIFF
--- a/camfort.cabal
+++ b/camfort.cabal
@@ -28,71 +28,10 @@ source-repository head
   location: https://github.com/camfort/camfort
 
 executable camfort
-  main-is: Main.hs
-  hs-source-dirs:       src
-  other-modules:        Camfort.Analysis.Annotations
-                        Camfort.Analysis.CommentAnnotator
-                        Camfort.Analysis.Simple
-                        Camfort.Specification.Parser
-                        Camfort.Specification.Stencils.Annotation
-                        Camfort.Specification.Stencils.CheckBackend
-                        Camfort.Specification.Stencils.CheckFrontend
-                        Camfort.Specification.Stencils.Consistency
-                        Camfort.Specification.Stencils.DenotationalSemantics
-                        Camfort.Specification.Stencils.Generate
-                        Camfort.Specification.Stencils.InferenceBackend
-                        Camfort.Specification.Stencils.InferenceFrontend
-                        Camfort.Specification.Stencils.Model
-                        Camfort.Specification.Stencils.Syntax
-                        Camfort.Specification.Stencils.Parser
-                        Camfort.Specification.Stencils.Parser.Types
-                        Camfort.Specification.Stencils.Synthesis
-                        Camfort.Specification.Stencils
-                        Camfort.Specification.Units
-                        Camfort.Specification.Units.InferenceFrontend
-                        Camfort.Specification.Units.InferenceBackend
-                        Camfort.Specification.Units.Environment
-                        Camfort.Specification.Units.Monad
-                        Camfort.Specification.Units.Parser
-                        Camfort.Specification.Units.Parser.Types
-                        Camfort.Specification.Units.Synthesis
-                        Camfort.Transformation.CommonBlockElim
-                        Camfort.Transformation.DeadCode
-                        Camfort.Transformation.EquivalenceElim
-                        Camfort.Helpers
-                        Camfort.Helpers.Syntax
-                        Camfort.Helpers.Vec
-                        Camfort.Functionality
-                        Camfort.Input
-                        Camfort.Output
-                        Camfort.Reprint
-                        Main
-
+  main-is: src/Main.hs
   build-depends:        base >= 4.6 && < 5,
-                        ghc-prim >= 0.3.1.0 && < 0.6,
-                        containers >= 0.5.0.0 && < 0.6,
-                        uniplate >= 1.6.10 && < 2,
-                        syz >= 0.2 && < 0.3,
-                        syb >= 0.4 && < 0.7,
-                        matrix >= 0.2.2 && < 0.4,
-                        vector >= 0.1 && < 0.12,
-                        hmatrix >= 0.15 && < 0.19,
-                        mtl >= 2.1 && < 3,
-                        text >= 0.11.2.3 && < 2,
-                        array >= 0.4 && < 0.6,
-                        directory >= 1.2 && < 2,
-                        transformers >= 0.4 && < 0.6,
-                        GenericPretty >= 1.2 && < 2,
-                        QuickCheck >= 2.8 && < 3,
-                        fortran-src >= 0.2.0.0 && < 0.3,
-                        filepath >= 1.4 && < 2,
-                        fgl >= 5.5 && < 6,
-                        bytestring >= 0.10 && < 0.11,
-                        binary >= 0.8.3.0 && < 0.9,
-                        lattices >= 1.5 && < 2,
-                        sbv >= 7.0 && < 8,
-                        partial-order >= 0.1.2,
-                        optparse-applicative >= 0.13.2.0 && < 0.14
+                        optparse-applicative >= 0.13.2.0 && < 0.14,
+                        camfort
   default-language: Haskell2010
 
 library


### PR DESCRIPTION
This halves the time for `stack build`