### PR TITLE
Support GHC 9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,10 @@ jobs:
       matrix:
         cabal: ["3.4"]      # latest as of 2021-06-16
         ghc:
-        - "8.6"
-        - "8.8"
-        - "8.10"
-        #- "9.0" # 2021-06-16: singletons 3.0 requires GHC 9.0 but changes too
-                 # effectively support older versions
+        #- "8.6"
+        #- "8.8"
+        #- "8.10"
+        - "9.0"
     steps:
     # note that we require static libs (in Ubuntu, *-dev)
     - name: Install required libraries

--- a/camfort.cabal
+++ b/camfort.cabal
@@ -206,7 +206,9 @@ library
     , pipes ==4.3.*
     , pretty >=1.1 && <2
     , sbv >=8.0 && <9
-    , singletons >=2.2 && <2.8
+    , singletons ==3.0.*
+    , singletons-base ==3.0.*
+    , singletons-th ==3.0.*
     , strict >=0.3.2 && <1
     , syb >=0.4 && <0.8
     , syz ==0.2.*

--- a/package.yaml
+++ b/package.yaml
@@ -141,7 +141,9 @@ library:
     - sbv >= 8.0 && < 9
     - lens >= 4.15.1 && < 6
     - mmorph >= 1.0.9 && < 2
-    - singletons >= 2.2 && < 2.8
+    - singletons      >= 3.0 && < 3.1
+    - singletons-th   >= 3.0 && < 3.1
+    - singletons-base >= 3.0 && < 3.1
     - template-haskell >= 2.11 && < 3
     - vinyl >= 0.9 && < 1.0
     - verifiable-expressions >= 0.6.0 && < 0.8.0

--- a/src/Language/Fortran/Model/Op/Core.hs
+++ b/src/Language/Fortran/Model/Op/Core.hs
@@ -27,8 +27,8 @@ module Language.Fortran.Model.Op.Core
 
 import           Data.Functor.Compose
 
-import           Data.Singletons.Prelude.List
-import           Data.Singletons.TypeLits
+import           Data.List.Singletons
+import           GHC.TypeLits.Singletons
 
 import           Data.Vinyl
 import           Data.Vinyl.Curry

--- a/src/Language/Fortran/Model/Op/Core/Core.hs
+++ b/src/Language/Fortran/Model/Op/Core/Core.hs
@@ -12,7 +12,7 @@
 -- TODO: Function calls
 module Language.Fortran.Model.Op.Core.Core where
 
-import           Data.Singletons.TypeLits
+import           GHC.TypeLits.Singletons
 
 import           Data.Vinyl
 

--- a/src/Language/Fortran/Model/Op/Core/Eval.hs
+++ b/src/Language/Fortran/Model/Op/Core/Eval.hs
@@ -26,8 +26,8 @@ import           Data.SBV.Dynamic                     (SVal)
 import qualified Data.SBV.Dynamic                     as SBV
 
 import           Data.Singletons
-import           Data.Singletons.Prelude.List
-import           Data.Singletons.TypeLits
+import           Data.List.Singletons
+import           GHC.TypeLits.Singletons
 
 import           Data.Vinyl                           hiding (Field)
 import           Data.Vinyl.Curry

--- a/src/Language/Fortran/Model/Op/Core/Match.hs
+++ b/src/Language/Fortran/Model/Op/Core/Match.hs
@@ -23,7 +23,7 @@ import           Data.Typeable
 import           Control.Lens
 
 import           Data.Singletons
-import           Data.Singletons.Prelude.List
+import           Data.List.Singletons
 
 import           Data.Vinyl                          hiding ((:~:), Field)
 

--- a/src/Language/Fortran/Model/Op/Meta.hs
+++ b/src/Language/Fortran/Model/Op/Meta.hs
@@ -28,7 +28,7 @@ import           Data.Vinyl                          (Rec, RMap, RApply, rmap, (
 import           Data.Vinyl.Functor                  (Lift (..))
 import           Data.Vinyl.Lens                     (RElem, rput)
 
-import           Data.Singletons.TypeLits
+import           GHC.TypeLits.Singletons
 
 import qualified Data.SBV.Dynamic                    as SBV
 

--- a/src/Language/Fortran/Model/Repr/Prim.hs
+++ b/src/Language/Fortran/Model/Repr/Prim.hs
@@ -205,7 +205,7 @@ class HasPrimReprHandlers r where
   primReprHandlers env = PrimReprHandlers (primReprHandler env)
 
   primReprHandler :: r -> Prim p k a -> PrimReprHandler a
-  primReprHandler = unPrimReprHandlers . primReprHandlers
+  primReprHandler env p = unPrimReprHandlers (primReprHandlers env) p
 
 newtype PrimReprHandlers =
   PrimReprHandlers { unPrimReprHandlers :: forall p k a. Prim p k a -> PrimReprHandler a }

--- a/src/Language/Fortran/Model/Singletons.hs
+++ b/src/Language/Fortran/Model/Singletons.hs
@@ -56,8 +56,8 @@ the result in that case is unspecified. Use 'BasicTypeMax' at the type level and
 -}
 module Language.Fortran.Model.Singletons where
 
-import Data.Singletons.Prelude
-import Data.Singletons.TH
+import Prelude.Singletons
+import Data.Singletons.Base.TH
 
 $(singletons
   [d|

--- a/src/Language/Fortran/Model/Translate.hs
+++ b/src/Language/Fortran/Model/Translate.hs
@@ -102,7 +102,7 @@ import           Control.Monad.Reader
 import           Data.Map                             (Map)
 
 import           Data.Singletons
-import           Data.Singletons.Prelude.List         (Length)
+import           Data.List.Singletons                 (Length)
 
 import           Data.Vinyl
 import           Data.Vinyl.Functor                   (Const (..))

--- a/src/Language/Fortran/Model/Types.hs
+++ b/src/Language/Fortran/Model/Types.hs
@@ -40,7 +40,7 @@ import           Data.Monoid                           (Endo (..))
 import           Data.Typeable                         (Typeable)
 import           Data.Word                             (Word8)
 
-import           Data.Singletons.TypeLits
+import           GHC.TypeLits.Singletons
 
 import           Data.Vinyl                            hiding (Field)
 import           Data.Vinyl.Functor                    hiding (Field)

--- a/src/Language/Fortran/Model/Types/Match.hs
+++ b/src/Language/Fortran/Model/Types/Match.hs
@@ -20,7 +20,7 @@ module Language.Fortran.Model.Types.Match where
 import           Data.Typeable
 
 import           Data.Singletons
-import           Data.Singletons.TypeLits
+import           GHC.TypeLits.Singletons
 import           GHC.TypeLits
 
 import           Data.Vinyl                        hiding ((:~:), Field)


### PR DESCRIPTION
singletons package has breaking changes that aren't easy to work around, so this changeset currently breaks all other prior support. Unless we can do some magic with optional dependencies or copy-paste all the singleton prelude utils and TH we use, I don't see a workaround.