### PR TITLE
Change format of logs of analyses

### DIFF
--- a/src/Camfort/Analysis/Logger.hs
+++ b/src/Camfort/Analysis/Logger.hs
@@ -131,6 +131,7 @@ class Describe a where
   describeBuilder = Builder.fromString . show
 
 instance Describe F.SrcSpan
+instance Describe F.Position
 instance Describe Text where
   describeBuilder = Builder.fromText
 instance Describe [Char] where
@@ -175,8 +176,14 @@ instance NFData Origin
 
 instance Describe Origin where
   describeBuilder origin =
+    -- Present the file and span in a standard format for
+    -- editor integration (link to source)
     "at [" <> Builder.fromString (origin ^. oFile) <>
-    ", " <> describeBuilder (origin ^. oSpan) <> "]"
+    ":" <> describeBuilder startSpan <>
+    " - " <> describeBuilder endSpan <> "]"
+    where
+      startSpan = F.ssFrom (origin ^. oSpan)
+      endSpan   = F.ssFrom (origin ^. oSpan)
 
 data ParsedOrigin = ParsedOrigin FilePath (Int, Int) (Int, Int)
   deriving (Show, Eq, Ord)


### PR DESCRIPTION
Previously, when running any of the `basic-checks` the output would format locations in the style of:

```filename.f90, (784:22 - 784:22)```

However, this prevents good editor integration. Instead this change switches the format to:

`filename.f90:784:22 - 784:22`

The first part can then be used as link by some IDEs and editors (e.g.. VSCode) to hyperlink into the code.