### PR TITLE
Update lts (bumping ghc to 9.2)

### DIFF
--- a/src/Camfort/Analysis/Logger.hs
+++ b/src/Camfort/Analysis/Logger.hs
@@ -131,6 +131,7 @@ class Describe a where
   describeBuilder = Builder.fromString . show
 
 instance Describe F.SrcSpan
+instance Describe F.Position
 instance Describe Text where
   describeBuilder = Builder.fromText
 instance Describe [Char] where
@@ -175,8 +176,14 @@ instance NFData Origin
 
 instance Describe Origin where
   describeBuilder origin =
+    -- Present the file and span in a standard format for
+    -- editor integration (link to source)
     "at [" <> Builder.fromString (origin ^. oFile) <>
-    ", " <> describeBuilder (origin ^. oSpan) <> "]"
+    ":" <> describeBuilder startSpan <>
+    " - " <> describeBuilder endSpan <> "]"
+    where
+      startSpan = F.ssFrom (origin ^. oSpan)
+      endSpan   = F.ssFrom (origin ^. oSpan)
 
 data ParsedOrigin = ParsedOrigin FilePath (Int, Int) (Int, Int)
   deriving (Show, Eq, Ord)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.20
+resolver: lts-20.01
 
 packages:
 - '.'
@@ -17,3 +17,4 @@ extra-deps:
 - syz-0.2.0.0@sha256:7307acb8f6ae7720e7e235c974281ecee912703c1394ebcac19caf83d70bb492,2345
   #- vinyl-0.13.3@sha256:4031f1cb791185fccd2237bf412fa831363812b95987b433159520d1a511fcac,4046
   #- union-0.1.2@rev:6
+- union-0.1.2@sha256:856669b7084f992ab7c369e64fefe3833814b35409ff67f1aad4657548b5a466,2134

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -25,9 +25,16 @@ packages:
       size: 256
   original:
     hackage: syz-0.2.0.0@sha256:7307acb8f6ae7720e7e235c974281ecee912703c1394ebcac19caf83d70bb492,2345
+- completed:
+    hackage: union-0.1.2@sha256:856669b7084f992ab7c369e64fefe3833814b35409ff67f1aad4657548b5a466,2134
+    pantry-tree:
+      sha256: 9c4d03a246ad23b8b066b000532b84a9b710395084a8bced697908750da689e6
+      size: 330
+  original:
+    hackage: union-0.1.2@sha256:856669b7084f992ab7c369e64fefe3833814b35409ff67f1aad4657548b5a466,2134
 snapshots:
 - completed:
-    sha256: be747117bed6d462806c883352c3206325b23480825103f5c87884e97e52819a
-    size: 619173
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/20.yaml
-  original: lts-19.20
+    sha256: b73b2b116143aea728c70e65c3239188998bac5bc3be56465813dacd74215dc5
+    size: 648424
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/1.yaml
+  original: lts-20.1


### PR DESCRIPTION
This enables CamFort to build on Apple silicon. 