### PR TITLE
add test for block unit annotations

### DIFF
--- a/tests/fixtures/Specification/Units/sqrtPoly-block.f90
+++ b/tests/fixtures/Specification/Units/sqrtPoly-block.f90
@@ -1,0 +1,20 @@
+program sqrtPoly
+  implicit none
+  != unit m :: x
+  != unit s :: y  
+  != unit J :: z
+  real :: x
+  real :: y
+  real :: z
+  integer :: a
+  integer :: b
+  integer :: c
+  x = sqrt(a)
+  y = sqrt(sqrt(b))
+  z = sqrt(square(sqrt(c)))
+contains
+  real function square(n)
+    real :: n
+    square = n * n
+  end function square
+end program sqrtPoly


### PR DESCRIPTION
sqrtPoly with all unit annotations at the top (instead of directly preceding each variable declaration)