### PR TITLE
Better cross module names

### DIFF
--- a/.github/workflows/disabled/hackage.yml
+++ b/.github/workflows/disabled/hackage.yml
@@ -79,14 +79,14 @@ jobs:
     - run: cabal sdist
 
     - name: Upload Hackage sdist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: dist-newstyle/sdist/${{ env.EXE_NAME }}-*.tar.gz
         name: ${{ env.EXE_NAME }}-sdist-${{ github.sha }}.tar.gz
         if-no-files-found: error
 
     - name: Upload Hackage Haddock docs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: dist-newstyle/${{ env.EXE_NAME }}-*-docs.tar.gz
         name: ${{ env.EXE_NAME }}-hackage-haddocks-${{ github.sha }}.tar.gz

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -52,7 +52,7 @@ jobs:
       run: stack --no-terminal install
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: ~/.local/bin/${{ env.exe }}
         name: ${{ env.exe }}-ubuntu-stack-${{ github.sha }}
@@ -172,10 +172,10 @@ jobs:
       env:
         HSPEC_OPTIONS: --color
 
-    # note that Cabal uses symlinks -- actions/upload-artifact@v2 apparently
+    # note that Cabal uses symlinks -- actions/upload-artifact@v4 apparently
     # dereferences for us
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: ~/.cabal/bin/${{ env.exe }}
         name: ${{ env.exe }}-macos-ghc-${{ matrix.ghc }}-cabal-${{ github.sha }}
@@ -267,11 +267,11 @@ jobs:
       env:
         BASH_ENV: /c/ghcup/env
 
-    # note that Cabal uses symlinks -- actions/upload-artifact@v2 apparently
+    # note that Cabal uses symlinks -- actions/upload-artifact@v4 apparently
     # dereferences for us
     - name: (camfort) Upload executable
       if: "matrix.build == 'release'"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: C:/cabal/bin/camfort.exe
         name: camfort-${{ runner.os }}-ghc_${{ matrix.ghc }}-cabal-${{ github.sha }}.exe
@@ -290,7 +290,7 @@ jobs:
         mv bundle "${{ env.exe }}-bundle-windows-msys2-${{ matrix.msystem }}-ghc-${{ matrix.ghc }}-cabal-${{ github.sha }}"
 
     - name: Upload self-contained bundle
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: "${{ env.exe }}-bundle-windows-msys2-${{ matrix.msystem }}-ghc-${{ matrix.ghc }}-cabal-${{ github.sha }}"
         name: "${{ env.exe }}-bundle-windows-msys2-${{ matrix.msystem }}-ghc-${{ matrix.ghc }}-cabal-${{ github.sha }}"

--- a/camfort.cabal
+++ b/camfort.cabal
@@ -400,7 +400,7 @@ executable camfort
     , directory >=1.2 && <2
     , fgl >=5.6 && <5.9
     , filepath ==1.4.*
-    , fortran-src >=0.16.0 && <0.17
+    , fortran-src >=0.16.2 && <0.17
     , hmatrix ==0.20.*
     , lattices >=2.0.0 && <2.1
     , lens >=4.15.1 && <6
@@ -456,7 +456,7 @@ test-suite spec
     , directory >=1.2 && <2
     , fgl >=5.6 && <5.9
     , filepath ==1.4.*
-    , fortran-src >=0.16.0 && <0.17
+    , fortran-src >=0.16.2 && <0.17
     , hmatrix ==0.20.*
     , hspec >=2.2 && <3
     , lattices >=2.0.0 && <2.1

--- a/camfort.cabal
+++ b/camfort.cabal
@@ -360,7 +360,7 @@ library
     , directory >=1.2 && <2
     , fgl >=5.6 && <5.9
     , filepath ==1.4.*
-    , fortran-src >=0.16.0 && <0.17
+    , fortran-src >=0.16.3 && <0.17
     , ghc-prim >=0.3.1.0 && <0.10
     , hmatrix ==0.20.*
     , lattices >=2.0.0 && <2.1
@@ -400,7 +400,7 @@ executable camfort
     , directory >=1.2 && <2
     , fgl >=5.6 && <5.9
     , filepath ==1.4.*
-    , fortran-src >=0.16.2 && <0.17
+    , fortran-src >=0.16.3 && <0.17
     , hmatrix ==0.20.*
     , lattices >=2.0.0 && <2.1
     , lens >=4.15.1 && <6
@@ -456,7 +456,7 @@ test-suite spec
     , directory >=1.2 && <2
     , fgl >=5.6 && <5.9
     , filepath ==1.4.*
-    , fortran-src >=0.16.2 && <0.17
+    , fortran-src >=0.16.3 && <0.17
     , hmatrix ==0.20.*
     , hspec >=2.2 && <3
     , lattices >=2.0.0 && <2.1

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ dependencies:
   - text >= 0.11.2.3 && < 2.1
   - mtl >= 2.1 && < 2.3
   - containers >= 0.5.0.0 && < 0.7
-  - fortran-src ^>= 0.16.0
+  - fortran-src ^>= 0.16.3
   - filepath >= 1.4 && < 1.5
   - fgl >= 5.6 && < 5.9
   - lattices >= 2.0.0 && < 2.1

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -353,15 +353,17 @@ runUnitsFunctionalityP
   -> (UnitOpts -> AnalysisProgram e w IO a b)
   -> AnalysisRunnerP e w IO a b (AnalysisReport e w b)
   -> LiteralsOpt
+  -> Bool
   -> CamfortEnv
   -> IO Int
-runUnitsFunctionalityP description unitsProgram runner opts =
-  let uo = optsToUnitOpts opts
+runUnitsFunctionalityP description unitsProgram runner opts uninits =
+  let uo = optsToUnitOpts opts uninits
   in runFunctionalityP description (unitsProgram uo) runner compileUnits uo
 
-optsToUnitOpts :: LiteralsOpt -> UnitOpts
-optsToUnitOpts m = o1
+optsToUnitOpts :: LiteralsOpt -> Bool -> UnitOpts
+optsToUnitOpts m uninits = o1
   where o1 = unitOpts0 { uoLiterals = m
+                       , uninitializeds = uninits
                        }
 
 singlePfUnits
@@ -405,8 +407,8 @@ multiPfUnits unitAnalysis opts pfs = do
 
   return (rs', ps)
 
-unitsDump :: LiteralsOpt -> CamfortEnv -> IO Int
-unitsDump _ env = do
+unitsDump :: LiteralsOpt -> Bool -> CamfortEnv -> IO Int
+unitsDump _ uninits env = do
   let modFileName = ceInputSources env
   modData <- LB.readFile modFileName
   let eResult = FM.decodeModFile modData
@@ -420,7 +422,7 @@ unitsDump _ env = do
         putStrLn . fromMaybe "unable to find units info" $ dumpModFileCompiledUnits modFile
       pure 0
 
-unitsCheck :: LiteralsOpt -> CamfortEnv -> IO Int
+unitsCheck :: LiteralsOpt -> Bool -> CamfortEnv -> IO Int
 unitsCheck =
   runUnitsFunctionalityP
   "Checking units for"
@@ -428,7 +430,7 @@ unitsCheck =
   (describePerFileAnalysisP "unit checking")
 
 
-unitsInfer :: Bool -> LiteralsOpt -> CamfortEnv -> IO Int
+unitsInfer :: Bool -> LiteralsOpt -> Bool -> CamfortEnv -> IO Int
 unitsInfer showAST =
   runUnitsFunctionalityP
   "Inferring units for"
@@ -496,9 +498,9 @@ decodeOneModFile path = do
       hPutStrLn stderr $ path ++ ": successfully parsed summary file."
       return modFiles
 
-unitsCompile :: LiteralsOpt -> CamfortEnv -> IO Int
-unitsCompile opts env = do
-  let uo = optsToUnitOpts opts
+unitsCompile :: LiteralsOpt -> Bool -> CamfortEnv -> IO Int
+unitsCompile opts uninits env = do
+  let uo = optsToUnitOpts opts uninits
   let description = "Compiling units for"
   putStrLn $ description ++ " '" ++ ceInputSources env ++ "'"
   incDir' <- maybe getCurrentDirectory pure (ceIncludeDir env)
@@ -551,22 +553,22 @@ unitsCompile opts env = do
   _allMods <- loop mg0 []
   return 0
 
-unitsSynth :: AnnotationType -> FileOrDir -> LiteralsOpt -> CamfortEnv -> IO Int
-unitsSynth annType outSrc opts env =
+unitsSynth :: AnnotationType -> FileOrDir -> LiteralsOpt -> Bool -> CamfortEnv -> IO Int
+unitsSynth annType outSrc opts uninits env =
   runFunctionality "Synthesising units for"
                    (multiPfUnits (LU.synthesiseUnits (markerChar annType)) uo)
                    (doRefactor "unit synthesis" (ceInputSources env) outSrc)
                    compileUnits
                    uo
                    env
-  where uo = optsToUnitOpts opts
+  where uo = optsToUnitOpts opts uninits
 
-unitsCriticals :: LiteralsOpt -> CamfortEnv -> IO Int
-unitsCriticals opts env =
+unitsCriticals :: LiteralsOpt -> Bool -> CamfortEnv -> IO Int
+unitsCriticals opts uninits env =
   runUnitsFunctionalityP
   "Suggesting variables to annotate with unit specifications in"
   (singlePfUnits (inferCriticalVariables localPath))
-  (describePerFileAnalysisP "unit critical variable analysis") opts env
+  (describePerFileAnalysisP "unit critical variable analysis") opts uninits env
   where
     localPath = takeDirectory (ceInputSources env)
 

--- a/src/Camfort/Specification/Stencils/Generate.hs
+++ b/src/Camfort/Specification/Stencils/Generate.hs
@@ -70,6 +70,7 @@ import           Camfort.Specification.Stencils.Syntax
   , Specification(..)
   , Variable)
 import           Language.Fortran.Repr
+
 type Indices a = [[F.Index (FA.Analysis a)]]
 
 type EvalLog = [(String, Variable)]

--- a/src/Camfort/Specification/Units/Analysis.hs
+++ b/src/Camfort/Specification/Units/Analysis.hs
@@ -199,10 +199,11 @@ insertUndeterminedUnitVar _ e = pure e
 toUnitVar :: DeclMap -> VV -> UnitInfo
 toUnitVar dmap (vname, sname) = unit
   where
-    unit = case fst <$> M.lookup vname dmap of
+    unit = case fst3 <$> M.lookup vname dmap of
       Just (DCFunction (F.Named fvname, F.Named fsname))   -> UnitParamVarAbs ((fvname, fsname), (vname, sname))
       Just (DCSubroutine (F.Named fvname, F.Named fsname)) -> UnitParamVarAbs ((fvname, fsname), (vname, sname))
       _                                                    -> UnitVar (vname, sname)
+    fst3 (a, _, _) = a
 
 -- Insert undetermined units annotations on the following types of variables.
 isAcceptableType :: FAS.SemType -> Bool

--- a/src/Camfort/Specification/Units/Analysis.hs
+++ b/src/Camfort/Specification/Units/Analysis.hs
@@ -135,7 +135,7 @@ runInference solver = do
 
   let (pf', _, _) = withCombinedEnvironment mfs . fmap UA.mkUnitAnnotation $ pf
   let pvm = combinedParamVarMap mfs
-  let pf'' = FAD.analyseConstExps . FAD.analyseParameterVars pvm . FAB.analyseBBlocks $ pf'
+  let pf'' = FAD.analyseParameterVars pvm . FAB.analyseBBlocks $ pf'
   runUnitSolver pf'' $ do
     initializeModFiles
     initInference

--- a/src/Camfort/Specification/Units/Analysis.hs
+++ b/src/Camfort/Specification/Units/Analysis.hs
@@ -135,7 +135,11 @@ runInference solver = do
 
   let (pf', _, _) = withCombinedEnvironment mfs . fmap UA.mkUnitAnnotation $ pf
   let pvm = combinedParamVarMap mfs
-  let pf'' = FAD.analyseParameterVars pvm . FAB.analyseBBlocks $ pf'
+    -- Previously we did
+  --  FAD.analyseConstExps . FAD.analyseParameterVars pvm
+  -- but we do not want to cause constant expression evaluation to 'squeeze out'
+  -- constant expressions from the analysis
+  let pf'' = FAB.analyseBBlocks $ pf'
   runUnitSolver pf'' $ do
     initializeModFiles
     initInference

--- a/src/Camfort/Specification/Units/Analysis/Criticals.hs
+++ b/src/Camfort/Specification/Units/Analysis/Criticals.hs
@@ -97,13 +97,6 @@ instance Show Criticals where
 
 instance Describe Criticals
 
--- | Return a list of critical variables as UnitInfo list (most likely
--- to be of the UnitVar constructor).
-runCriticalVariables :: UnitSolver [UnitInfo]
-runCriticalVariables = do
-  cons <- usConstraints `fmap` get
-  return $ criticalVariables cons
-
 -- | Infer one possible set of critical variables for a program.
 -- \ (depends on first doing inference)
 inferCriticalVariables :: FilePath -> UnitAnalysis Criticals
@@ -141,3 +134,11 @@ inferCriticalVariables localPath = do
                      , criticalsUniqMap      = uniqnameMap `M.union` uniqnameMap'
                      , criticalsFromWhere    = fromWhereMap
                      }
+
+-- (not used)
+-- | Return a list of critical variables as UnitInfo list (most likely
+-- to be of the UnitVar constructor).
+runCriticalVariables :: UnitSolver [UnitInfo]
+runCriticalVariables = do
+  cons <- usConstraints `fmap` get
+  return $ criticalVariables cons

--- a/src/Camfort/Specification/Units/Analysis/Criticals.hs
+++ b/src/Camfort/Specification/Units/Analysis/Criticals.hs
@@ -91,7 +91,8 @@ instance Show Criticals where
         numVars   = M.size dmapSubset -- should be same as M.size criticalVarNames
 
         -- Generate report
-        declReport (v, (_, ss)) = vfilename ++ ":" ++ showSpanStart ss ++ "    " ++ fromMaybe v (M.lookup v uniqnameMap)
+        declReport (v, (_, ss)) =
+          vfilename ++ ":" ++ showSpanStart ss ++ "    " ++ fromMaybe v (M.lookup v uniqnameMap)
           where vfilename = fromMaybe fname $ M.lookup v fromWhereMap
                 showSpanStart (FU.SrcSpan l _) = show l
 

--- a/src/Camfort/Specification/Units/InferenceBackendSBV.hs
+++ b/src/Camfort/Specification/Units/InferenceBackendSBV.hs
@@ -216,6 +216,8 @@ engine cons = unsafePerformIO $ do
               -- convert to Constraint format
               let polyCons = map dimToConstraint dims'
 
+              let criticals = MatrixBackend.criticalVariables polyCons
+
               -- feed back into old solver to figure out polymorphic equations
               let polyAssigns = MatrixBackend.genUnitAssignments polyCons
 
@@ -224,7 +226,6 @@ engine cons = unsafePerformIO $ do
                                          | ([UnitPow u@(UnitParamVarAbs _) k], units) <- polyAssigns
                                          , k `approxEq` 1 ]
 
-              let criticals = MatrixBackend.criticalVariables polyCons
 
               -- for now we'll suggest all underdetermined units but
               -- this should be cut down by considering the

--- a/src/Camfort/Specification/Units/Monad.hs
+++ b/src/Camfort/Specification/Units/Monad.hs
@@ -65,7 +65,7 @@ import           Control.Monad.State.Strict
 import qualified Language.Fortran.AST as F
 
 unitOpts0 :: UnitOpts
-unitOpts0 = UnitOpts LitMixed
+unitOpts0 = UnitOpts LitMixed False
 
 --------------------------------------------------
 

--- a/src/Camfort/Specification/Units/MonadTypes.hs
+++ b/src/Camfort/Specification/Units/MonadTypes.hs
@@ -44,6 +44,7 @@ instance Read LiteralsOpt where
 -- | Options for the unit solver
 data UnitOpts = UnitOpts
   { uoLiterals :: LiteralsOpt               -- ^ how to handle literals
+  , uninitializeds :: Bool                   -- ^ whether to suggest for uninitialized variables
   }
   deriving (Show, Data, Eq, Ord)
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -86,7 +86,7 @@ realMain = do
     runUO uo f =
       let ro = uoReadOptions uo
           lo = uoLogOptions uo
-      in runRO ro lo (f (literals uo))
+      in runRO ro lo (f (literals uo) (includeUninitialized uo))
     runUWO uwo f =
       let uo     = uwoUnitsOptions uwo
           ro     = uoReadOptions uo
@@ -205,6 +205,7 @@ data UnitsOptions = UnitsOptions
   , literals      :: LiteralsOpt
   , uoDumpMode    :: Bool
   , uoShowAST     :: Bool
+  , includeUninitialized :: Bool
   }
 
 
@@ -354,6 +355,7 @@ unitsOptions = fmap UnitsOptions
   <*> literalsOption
   <*> dumpModFileOption
   <*> showASTOption
+  <*> pure False
   where
     literalsOption = option parseLiterals $
                      long "units-literals"
@@ -366,6 +368,11 @@ unitsOptions = fmap UnitsOptions
     showASTOption = switch (long "show-ast" <> help "show units at each AST node")
     parseLiterals = fmap read str
 
+unitsSuggestOptions :: Parser UnitsOptions
+unitsSuggestOptions =
+    (fmap (\f b -> f { includeUninitialized = b }) unitsOptions) <*> uninitOption
+  where
+    uninitOption = switch (long "include-uninit" <> help "include suggestions for uninitialized variables")
 
 invariantsOptions :: Parser InvariantsOptions
 invariantsOptions = fmap InvariantsOptions
@@ -420,7 +427,7 @@ cmdStencilsSynth = fmap CmdStencilsSynth stencilsSynthOptions
 
 
 cmdUnitsSuggest, cmdUnitsCheck, cmdUnitsInfer, cmdUnitsCompile, cmdUnitsSynth :: Parser Command
-cmdUnitsSuggest = fmap CmdUnitsSuggest unitsOptions
+cmdUnitsSuggest = fmap CmdUnitsSuggest unitsSuggestOptions
 cmdUnitsCheck   = fmap CmdUnitsCheck   unitsOptions
 cmdUnitsInfer   = fmap CmdUnitsInfer   unitsOptions
 cmdUnitsCompile = fmap CmdUnitsCompile unitsOptions

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ allow-newer: true
 #   - git: https://github.com/camfort/fortran-src
 #     commit: <commit hash>
 extra-deps:
+# fortran-src latest
 - fortran-src-0.16.3
 - verifiable-expressions-0.6.2@sha256:cefdc5d3d9a4cff4ce0bfaa27ccdf83ff46bcd17340ac0c5cf6fcbe88ce05a61,1739
   #- sbv-8.15@sha256:bc0ea4e3564626030ac2cb21905b97cd9bd25fddcd6d6010834e8cc2ebf79067,29016

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,7 +13,7 @@ allow-newer: true
 #   - git: https://github.com/camfort/fortran-src
 #     commit: <commit hash>
 extra-deps:
-- fortran-src-0.16.0
+- fortran-src-0.16.3
 - verifiable-expressions-0.6.2@sha256:cefdc5d3d9a4cff4ce0bfaa27ccdf83ff46bcd17340ac0c5cf6fcbe88ce05a61,1739
   #- sbv-8.15@sha256:bc0ea4e3564626030ac2cb21905b97cd9bd25fddcd6d6010834e8cc2ebf79067,29016
   #- libBF-0.6.2@sha256:7bffc0e4dbc9bd9e851ba5c29255b62fd2c288dbc9a401cd3761b740f013775e,1770

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: fortran-src-0.16.0@sha256:115a70f64acdf9af77785bf3edd9f3f218450e223beadaa691ea6025698d0dd2,12633
+    hackage: fortran-src-0.16.3@sha256:873b2c95fd313beac794f5efe75fc4b9171a96c6db27d99e2d4231c7f40072e5,12633
     pantry-tree:
-      sha256: 02d2e4933dae057d9db9cdd723d0850b60ac5b5edd5e8c4ca6c7e7dc4511cc47
+      sha256: ac67370e895a79c315a96a3f1f0d7ae11efdbc7cc9adc0d42b9200963dd7b54f
       size: 12882
   original:
-    hackage: fortran-src-0.16.0
+    hackage: fortran-src-0.16.3
 - completed:
     hackage: verifiable-expressions-0.6.2@sha256:cefdc5d3d9a4cff4ce0bfaa27ccdf83ff46bcd17340ac0c5cf6fcbe88ce05a61,1739
     pantry-tree:

--- a/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
@@ -62,16 +62,20 @@ exampleCriticals2CriticalsReport =
 
 exampleCriticals3CriticalsReport :: String
 exampleCriticals3CriticalsReport =
- "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90: 3 variable declarations suggested to be given a specification:\n\
+ "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90: 5 variable declarations suggested to be given a specification:\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:7:11    b\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:5:11    a3\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:9:11    b3\n"
+ \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:9:11    b3\n\
+ \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:11:11    x0\n\
+ \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:12:13    x1\n"
 
 exampleCriticals4CriticalsReport :: String
 exampleCriticals4CriticalsReport =
- "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90: 5 variable declarations suggested to be given a specification:\n\
+ "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90: 7 variable declarations suggested to be given a specification:\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:5:17    a\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:7:11    b\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:11:13    foo_out\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:18:13    foo3\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:24:15    x\n"
+ \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:24:15    x\n\
+ \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:30:13    foo5\n\
+ \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:31:13    x\n"

--- a/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
@@ -4,7 +4,7 @@ import           Camfort.Analysis hiding (describe)
 import           Camfort.Analysis.ModFile (readParseSrcDir, genModFiles)
 import           Camfort.Specification.Units.Analysis (compileUnits)
 import           Camfort.Specification.Units.Analysis.Criticals (inferCriticalVariables)
-import           Camfort.Specification.Units.Monad (LiteralsOpt(..), unitOpts0, uoLiterals, UnitEnv(..), runUnitAnalysis)
+import           Camfort.Specification.Units.Monad (LiteralsOpt(..), unitOpts0, UnitOpts, uoLiterals, uninitializeds, UnitEnv(..), runUnitAnalysis)
 import           Control.Lens
 import           Language.Fortran.Util.ModFile (emptyModFiles)
 import           System.FilePath ((</>))
@@ -17,25 +17,33 @@ spec :: Test.Spec
 spec = do
   describe "critical-units analysis" $ do
     it "reports critical variables" $
-       unitsCriticalsReportIs LitMixed [] "example-criticals-1.f90" exampleCriticals1CriticalsReport
+       unitsCriticalsReportIs LitMixed False [] "example-criticals-1.f90" exampleCriticals1CriticalsReport
     it "reports when no additional variables need to be annotated" $
-       unitsCriticalsReportIs LitMixed [] "example-criticals-2.f90" exampleCriticals2CriticalsReport
+       unitsCriticalsReportIs LitMixed False [] "example-criticals-2.f90" exampleCriticals2CriticalsReport
+
+    it "criticals with uninitialized variables included" $
+       unitsCriticalsReportIs LitMixed True [] "uninitialised.f90" exampleCriticalUninitMixed
+
+    it "criticals with uninitialized variables included" $
+       unitsCriticalsReportIs LitPoly True [] "uninitialised.f90" exampleCriticalUninit
+
+
     it "reports correct locales across modules" $ do
-       unitsCriticalsReportIs LitPoly ["cross-module-c" </> "cross-module-c1.f90"]
+       unitsCriticalsReportIs LitPoly False ["cross-module-c" </> "cross-module-c1.f90"]
             ("cross-module-c" </> "cross-module-c3.f90") exampleCriticals3CriticalsReport
     it "reports correct locales across modules and in functions" $ do
-       unitsCriticalsReportIs LitPoly ["cross-module-c" </> "cross-module-c1.f90"]
+       unitsCriticalsReportIs LitPoly False ["cross-module-c" </> "cross-module-c1.f90"]
             ("cross-module-c" </> "cross-module-c1.f90") exampleCriticals4CriticalsReport
 
 fixturesDir :: String
 fixturesDir = "tests" </> "fixtures" </> "Specification" </> "Units"
 
 -- | Assert that the report of performing units inference on a file is as expected.
-unitsCriticalsReportIs :: LiteralsOpt -> [String] -> String -> String -> Expectation
-unitsCriticalsReportIs litmode modNames fileName expectedReport = do
+unitsCriticalsReportIs :: LiteralsOpt -> Bool -> [String] -> String -> String -> Expectation
+unitsCriticalsReportIs litmode uninitmode modNames fileName expectedReport = do
   let file = fixturesDir </> fileName
       modPaths = fmap (fixturesDir </>) modNames
-  modFiles <- mapM (mkTestModFile litmode) modPaths
+  modFiles <- mapM (mkTestModFile uOpts) modPaths
   [(pf,_)] <- readParseSrcDir Nothing modFiles file []
 
   let uEnv = UnitEnv { unitOpts = uOpts, unitProgramFile = pf }
@@ -44,11 +52,13 @@ unitsCriticalsReportIs litmode modNames fileName expectedReport = do
   let res = report ^?! arResult . _ARSuccess
 
   hideFormatting (show res) `shouldBe` expectedReport
-  where uOpts = unitOpts0 { uoLiterals = litmode }
+  where uOpts = unitOpts0 { uoLiterals = litmode, uninitializeds = uninitmode }
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
-mkTestModFile :: LiteralsOpt -> String -> IO ModFile
-mkTestModFile litmode file = head <$> genModFiles Nothing emptyModFiles compileUnits (unitOpts0 { uoLiterals = litmode }) file []
+
+mkTestModFile :: UnitOpts -> String -> IO ModFile
+mkTestModFile uopts file =
+  head <$> genModFiles Nothing emptyModFiles compileUnits uopts file []
 
 exampleCriticals1CriticalsReport :: String
 exampleCriticals1CriticalsReport =
@@ -80,3 +90,14 @@ exampleCriticals4CriticalsReport =
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:24:15    x\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:30:13    foo5\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:31:13    x\n"
+
+exampleCriticalUninitMixed :: String
+exampleCriticalUninitMixed =
+  "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90: 1 variable declarations suggested to be given a specification:\n\
+\    tests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90:5:13    not_initialised\n"
+
+exampleCriticalUninit :: String
+exampleCriticalUninit =
+  "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90: 2 variable declarations suggested to be given a specification:\n\
+\    tests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90:7:13    initialised\n\
+\    tests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90:5:13    not_initialised\n"

--- a/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
@@ -35,7 +35,7 @@ unitsCriticalsReportIs :: LiteralsOpt -> [String] -> String -> String -> Expecta
 unitsCriticalsReportIs litmode modNames fileName expectedReport = do
   let file = fixturesDir </> fileName
       modPaths = fmap (fixturesDir </>) modNames
-  modFiles <- mapM mkTestModFile modPaths
+  modFiles <- mapM (mkTestModFile litmode) modPaths
   [(pf,_)] <- readParseSrcDir Nothing modFiles file []
 
   let uEnv = UnitEnv { unitOpts = uOpts, unitProgramFile = pf }
@@ -47,8 +47,8 @@ unitsCriticalsReportIs litmode modNames fileName expectedReport = do
   where uOpts = unitOpts0 { uoLiterals = litmode }
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
-mkTestModFile :: String -> IO ModFile
-mkTestModFile file = head <$> genModFiles Nothing emptyModFiles compileUnits unitOpts0 file []
+mkTestModFile :: LiteralsOpt -> String -> IO ModFile
+mkTestModFile litmode file = head <$> genModFiles Nothing emptyModFiles compileUnits (unitOpts0 { uoLiterals = litmode }) file []
 
 exampleCriticals1CriticalsReport :: String
 exampleCriticals1CriticalsReport =

--- a/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
@@ -62,8 +62,9 @@ exampleCriticals2CriticalsReport =
 
 exampleCriticals3CriticalsReport :: String
 exampleCriticals3CriticalsReport =
- "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90: 5 variable declarations suggested to be given a specification:\n\
+ "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90: 6 variable declarations suggested to be given a specification:\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:7:11    b\n\
+ \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:13:13    d\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:5:11    a3\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:9:11    b3\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:11:11    x0\n\

--- a/tests/fixtures/Specification/Units/cross-module-c/cross-module-c1.f90
+++ b/tests/fixtures/Specification/Units/cross-module-c/cross-module-c1.f90
@@ -25,5 +25,10 @@ module c1
     real :: c = 4.0
     x = c
   end subroutine foo4
-
+  ! function whose parameter needs to get constraint somewhere else
+  function foo5(x)
+    real :: foo5
+    real :: x
+    foo5 = 1.0
+  end function foo5
 end module c1

--- a/tests/fixtures/Specification/Units/cross-module-c/cross-module-c3.f90
+++ b/tests/fixtures/Specification/Units/cross-module-c/cross-module-c3.f90
@@ -13,6 +13,6 @@ module c3
   contains
   subroutine foo()
     x0 = foo5(x1)
-    b3 = a / b
+    b3 = a / b + foo2()
   end subroutine foo
 end module c3

--- a/tests/fixtures/Specification/Units/cross-module-c/cross-module-c3.f90
+++ b/tests/fixtures/Specification/Units/cross-module-c/cross-module-c3.f90
@@ -7,8 +7,12 @@ module c3
   !
   ! another constant
   real :: b3 = 2.0
+  ! another global
+  real :: x0
+    real :: x1
   contains
   subroutine foo()
+    x0 = foo5(x1)
     b3 = a / b
   end subroutine foo
 end module c3

--- a/tests/fixtures/Specification/Units/uninitialised.f90
+++ b/tests/fixtures/Specification/Units/uninitialised.f90
@@ -1,0 +1,9 @@
+module unused_modvar
+
+    implicit none
+
+    real :: not_initialised
+
+    real :: initialised = 5.0
+
+end module


### PR DESCRIPTION
There have been some updates to fortran-src which provide more information in mod files now (https://github.com/camfort/fortran-src/pull/289). This should fix #184 with a test in `cross-module-c` where
doing `units-compile` on `cross-module-c1.f90` (with poly units) and then `units-suggest` on `cross-module-c3.f90` was producing a suggestion for `c1_foo2_d` in `cross-module-c3` which is now properly being reported as `d` in `cross-module-c1`.


Remaining
- [x] make all tests pass in `stack test` (there is something funky going on where the test I have above is doing something different when run through the golden test infrastructure, compared to doing it by hand on the terminal)