### PR TITLE
Allow `units-suggest` to suggest units for uninitialized variables (fixes #187)

### DIFF
--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -353,15 +353,17 @@ runUnitsFunctionalityP
   -> (UnitOpts -> AnalysisProgram e w IO a b)
   -> AnalysisRunnerP e w IO a b (AnalysisReport e w b)
   -> LiteralsOpt
+  -> Bool
   -> CamfortEnv
   -> IO Int
-runUnitsFunctionalityP description unitsProgram runner opts =
-  let uo = optsToUnitOpts opts
+runUnitsFunctionalityP description unitsProgram runner opts uninits =
+  let uo = optsToUnitOpts opts uninits
   in runFunctionalityP description (unitsProgram uo) runner compileUnits uo
 
-optsToUnitOpts :: LiteralsOpt -> UnitOpts
-optsToUnitOpts m = o1
+optsToUnitOpts :: LiteralsOpt -> Bool -> UnitOpts
+optsToUnitOpts m uninits = o1
   where o1 = unitOpts0 { uoLiterals = m
+                       , uninitializeds = uninits
                        }
 
 singlePfUnits
@@ -405,8 +407,8 @@ multiPfUnits unitAnalysis opts pfs = do
 
   return (rs', ps)
 
-unitsDump :: LiteralsOpt -> CamfortEnv -> IO Int
-unitsDump _ env = do
+unitsDump :: LiteralsOpt -> Bool -> CamfortEnv -> IO Int
+unitsDump _ uninits env = do
   let modFileName = ceInputSources env
   modData <- LB.readFile modFileName
   let eResult = FM.decodeModFile modData
@@ -420,7 +422,7 @@ unitsDump _ env = do
         putStrLn . fromMaybe "unable to find units info" $ dumpModFileCompiledUnits modFile
       pure 0
 
-unitsCheck :: LiteralsOpt -> CamfortEnv -> IO Int
+unitsCheck :: LiteralsOpt -> Bool -> CamfortEnv -> IO Int
 unitsCheck =
   runUnitsFunctionalityP
   "Checking units for"
@@ -428,7 +430,7 @@ unitsCheck =
   (describePerFileAnalysisP "unit checking")
 
 
-unitsInfer :: Bool -> LiteralsOpt -> CamfortEnv -> IO Int
+unitsInfer :: Bool -> LiteralsOpt -> Bool -> CamfortEnv -> IO Int
 unitsInfer showAST =
   runUnitsFunctionalityP
   "Inferring units for"
@@ -496,9 +498,9 @@ decodeOneModFile path = do
       hPutStrLn stderr $ path ++ ": successfully parsed summary file."
       return modFiles
 
-unitsCompile :: LiteralsOpt -> CamfortEnv -> IO Int
-unitsCompile opts env = do
-  let uo = optsToUnitOpts opts
+unitsCompile :: LiteralsOpt -> Bool -> CamfortEnv -> IO Int
+unitsCompile opts uninits env = do
+  let uo = optsToUnitOpts opts uninits
   let description = "Compiling units for"
   putStrLn $ description ++ " '" ++ ceInputSources env ++ "'"
   incDir' <- maybe getCurrentDirectory pure (ceIncludeDir env)
@@ -551,22 +553,22 @@ unitsCompile opts env = do
   _allMods <- loop mg0 []
   return 0
 
-unitsSynth :: AnnotationType -> FileOrDir -> LiteralsOpt -> CamfortEnv -> IO Int
-unitsSynth annType outSrc opts env =
+unitsSynth :: AnnotationType -> FileOrDir -> LiteralsOpt -> Bool -> CamfortEnv -> IO Int
+unitsSynth annType outSrc opts uninits env =
   runFunctionality "Synthesising units for"
                    (multiPfUnits (LU.synthesiseUnits (markerChar annType)) uo)
                    (doRefactor "unit synthesis" (ceInputSources env) outSrc)
                    compileUnits
                    uo
                    env
-  where uo = optsToUnitOpts opts
+  where uo = optsToUnitOpts opts uninits
 
-unitsCriticals :: LiteralsOpt -> CamfortEnv -> IO Int
-unitsCriticals opts env =
+unitsCriticals :: LiteralsOpt -> Bool -> CamfortEnv -> IO Int
+unitsCriticals opts uninits env =
   runUnitsFunctionalityP
   "Suggesting variables to annotate with unit specifications in"
   (singlePfUnits (inferCriticalVariables localPath))
-  (describePerFileAnalysisP "unit critical variable analysis") opts env
+  (describePerFileAnalysisP "unit critical variable analysis") opts uninits env
   where
     localPath = takeDirectory (ceInputSources env)
 

--- a/src/Camfort/Specification/Units/Monad.hs
+++ b/src/Camfort/Specification/Units/Monad.hs
@@ -65,7 +65,7 @@ import           Control.Monad.State.Strict
 import qualified Language.Fortran.AST as F
 
 unitOpts0 :: UnitOpts
-unitOpts0 = UnitOpts LitMixed
+unitOpts0 = UnitOpts LitMixed False
 
 --------------------------------------------------
 

--- a/src/Camfort/Specification/Units/MonadTypes.hs
+++ b/src/Camfort/Specification/Units/MonadTypes.hs
@@ -44,6 +44,7 @@ instance Read LiteralsOpt where
 -- | Options for the unit solver
 data UnitOpts = UnitOpts
   { uoLiterals :: LiteralsOpt               -- ^ how to handle literals
+  , uninitializeds :: Bool                   -- ^ whether to suggest for uninitialized variables
   }
   deriving (Show, Data, Eq, Ord)
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -355,7 +355,7 @@ unitsOptions = fmap UnitsOptions
   <*> literalsOption
   <*> dumpModFileOption
   <*> showASTOption
-  <*> uninitOption
+  <*> pure False
   where
     literalsOption = option parseLiterals $
                      long "units-literals"
@@ -366,10 +366,13 @@ unitsOptions = fmap UnitsOptions
                      <> help "units-of-measure literals mode. ID = Unitless, Poly, or Mixed"
     dumpModFileOption = switch (long "dump-mod-file" <> help "show contents of fsmod file")
     showASTOption = switch (long "show-ast" <> help "show units at each AST node")
-    uninitOption = switch (long "include-uninit" <> help "include suggestions for uninitialized variables")
-
     parseLiterals = fmap read str
 
+unitsSuggestOptions :: Parser UnitsOptions
+unitsSuggestOptions =
+    (fmap (\f b -> f { includeUninitialized = b }) unitsOptions) <*> uninitOption
+  where
+    uninitOption = switch (long "include-uninit" <> help "include suggestions for uninitialized variables")
 
 invariantsOptions :: Parser InvariantsOptions
 invariantsOptions = fmap InvariantsOptions
@@ -424,7 +427,7 @@ cmdStencilsSynth = fmap CmdStencilsSynth stencilsSynthOptions
 
 
 cmdUnitsSuggest, cmdUnitsCheck, cmdUnitsInfer, cmdUnitsCompile, cmdUnitsSynth :: Parser Command
-cmdUnitsSuggest = fmap CmdUnitsSuggest unitsOptions
+cmdUnitsSuggest = fmap CmdUnitsSuggest unitsSuggestOptions
 cmdUnitsCheck   = fmap CmdUnitsCheck   unitsOptions
 cmdUnitsInfer   = fmap CmdUnitsInfer   unitsOptions
 cmdUnitsCompile = fmap CmdUnitsCompile unitsOptions

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -86,7 +86,7 @@ realMain = do
     runUO uo f =
       let ro = uoReadOptions uo
           lo = uoLogOptions uo
-      in runRO ro lo (f (literals uo))
+      in runRO ro lo (f (literals uo) (includeUninitialized uo))
     runUWO uwo f =
       let uo     = uwoUnitsOptions uwo
           ro     = uoReadOptions uo
@@ -205,6 +205,7 @@ data UnitsOptions = UnitsOptions
   , literals      :: LiteralsOpt
   , uoDumpMode    :: Bool
   , uoShowAST     :: Bool
+  , includeUninitialized :: Bool
   }
 
 
@@ -354,6 +355,7 @@ unitsOptions = fmap UnitsOptions
   <*> literalsOption
   <*> dumpModFileOption
   <*> showASTOption
+  <*> uninitOption
   where
     literalsOption = option parseLiterals $
                      long "units-literals"
@@ -364,6 +366,8 @@ unitsOptions = fmap UnitsOptions
                      <> help "units-of-measure literals mode. ID = Unitless, Poly, or Mixed"
     dumpModFileOption = switch (long "dump-mod-file" <> help "show contents of fsmod file")
     showASTOption = switch (long "show-ast" <> help "show units at each AST node")
+    uninitOption = switch (long "include-uninit" <> help "include suggestions for uninitialized variables")
+
     parseLiterals = fmap read str
 
 

--- a/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
@@ -4,7 +4,7 @@ import           Camfort.Analysis hiding (describe)
 import           Camfort.Analysis.ModFile (readParseSrcDir, genModFiles)
 import           Camfort.Specification.Units.Analysis (compileUnits)
 import           Camfort.Specification.Units.Analysis.Criticals (inferCriticalVariables)
-import           Camfort.Specification.Units.Monad (LiteralsOpt(..), unitOpts0, uoLiterals, UnitEnv(..), runUnitAnalysis)
+import           Camfort.Specification.Units.Monad (LiteralsOpt(..), unitOpts0, UnitOpts, uoLiterals, uninitializeds, UnitEnv(..), runUnitAnalysis)
 import           Control.Lens
 import           Language.Fortran.Util.ModFile (emptyModFiles)
 import           System.FilePath ((</>))
@@ -17,25 +17,33 @@ spec :: Test.Spec
 spec = do
   describe "critical-units analysis" $ do
     it "reports critical variables" $
-       unitsCriticalsReportIs LitMixed [] "example-criticals-1.f90" exampleCriticals1CriticalsReport
+       unitsCriticalsReportIs LitMixed False [] "example-criticals-1.f90" exampleCriticals1CriticalsReport
     it "reports when no additional variables need to be annotated" $
-       unitsCriticalsReportIs LitMixed [] "example-criticals-2.f90" exampleCriticals2CriticalsReport
+       unitsCriticalsReportIs LitMixed False [] "example-criticals-2.f90" exampleCriticals2CriticalsReport
+
+    it "criticals with uninitialized variables included" $
+       unitsCriticalsReportIs LitMixed True [] "uninitialised.f90" exampleCriticalUninitMixed
+
+    it "criticals with uninitialized variables included" $
+       unitsCriticalsReportIs LitPoly True [] "uninitialised.f90" exampleCriticalUninit
+
+
     it "reports correct locales across modules" $ do
-       unitsCriticalsReportIs LitPoly ["cross-module-c" </> "cross-module-c1.f90"]
+       unitsCriticalsReportIs LitPoly False ["cross-module-c" </> "cross-module-c1.f90"]
             ("cross-module-c" </> "cross-module-c3.f90") exampleCriticals3CriticalsReport
     it "reports correct locales across modules and in functions" $ do
-       unitsCriticalsReportIs LitPoly ["cross-module-c" </> "cross-module-c1.f90"]
+       unitsCriticalsReportIs LitPoly False ["cross-module-c" </> "cross-module-c1.f90"]
             ("cross-module-c" </> "cross-module-c1.f90") exampleCriticals4CriticalsReport
 
 fixturesDir :: String
 fixturesDir = "tests" </> "fixtures" </> "Specification" </> "Units"
 
 -- | Assert that the report of performing units inference on a file is as expected.
-unitsCriticalsReportIs :: LiteralsOpt -> [String] -> String -> String -> Expectation
-unitsCriticalsReportIs litmode modNames fileName expectedReport = do
+unitsCriticalsReportIs :: LiteralsOpt -> Bool -> [String] -> String -> String -> Expectation
+unitsCriticalsReportIs litmode uninitmode modNames fileName expectedReport = do
   let file = fixturesDir </> fileName
       modPaths = fmap (fixturesDir </>) modNames
-  modFiles <- mapM mkTestModFile modPaths
+  modFiles <- mapM (mkTestModFile uOpts) modPaths
   [(pf,_)] <- readParseSrcDir Nothing modFiles file []
 
   let uEnv = UnitEnv { unitOpts = uOpts, unitProgramFile = pf }
@@ -44,11 +52,12 @@ unitsCriticalsReportIs litmode modNames fileName expectedReport = do
   let res = report ^?! arResult . _ARSuccess
 
   hideFormatting (show res) `shouldBe` expectedReport
-  where uOpts = unitOpts0 { uoLiterals = litmode }
+  where uOpts = unitOpts0 { uoLiterals = litmode, uninitializeds = uninitmode }
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
-mkTestModFile :: String -> IO ModFile
-mkTestModFile file = head <$> genModFiles Nothing emptyModFiles compileUnits unitOpts0 file []
+mkTestModFile :: UnitOpts -> String -> IO ModFile
+mkTestModFile uopts file =
+  head <$> genModFiles Nothing emptyModFiles compileUnits uopts file []
 
 exampleCriticals1CriticalsReport :: String
 exampleCriticals1CriticalsReport =
@@ -80,3 +89,14 @@ exampleCriticals4CriticalsReport =
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:24:15    x\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:30:13    foo5\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:31:13    x\n"
+
+exampleCriticalUninitMixed :: String
+exampleCriticalUninitMixed =
+  "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90: 1 variable declarations suggested to be given a specification:\n\
+\    tests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90:5:13    not_initialised\n"
+
+exampleCriticalUninit :: String
+exampleCriticalUninit =
+  "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90: 2 variable declarations suggested to be given a specification:\n\
+\    tests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90:7:13    initialised\n\
+\    tests" </> "fixtures" </> "Specification" </> "Units" </> "uninitialised.f90:5:13    not_initialised\n"

--- a/tests/fixtures/Specification/Units/uninitialised.f90
+++ b/tests/fixtures/Specification/Units/uninitialised.f90
@@ -1,0 +1,9 @@
+module unused_modvar
+
+    implicit none
+
+    real :: not_initialised
+
+    real :: initialised = 5.0
+
+end module


### PR DESCRIPTION
This fixes https://github.com/camfort/camfort/issues/187.
Previously 

```module unused_modvar
    implicit none
    real :: not_initialised
    real :: initialised = 5.0
end module
```
for `camfort units-suggest uninitialised.f90 -l poly` would only suggest that `initialised` needs annotating in poly mode or nothing in mixed mode. Now there is a new flag `--include-uninit` which gives:

```
% camfort units-suggest tests/fixtures/Specification/Units/uninitialised.f90 --include-uninit
Suggesting variables to annotate with unit specifications in 'tests/fixtures/Specification/Units/uninitialised.f90'
Successfully parsed 0 summary file(s).
Finished running unit critical variable analysis on input 'tests/fixtures/Specification/Units/uninitialised.f90' ...
Logs:

Result... OK:

tests/fixtures/Specification/Units/uninitialised.f90: 1 variable declarations suggested to be given a specification:
    tests/fixtures/Specification/Units/uninitialised.f90:5:13    not_initialised

% camfort units-suggest tests/fixtures/Specification/Units/uninitialised.f90 --include-uninit -l poly
Suggesting variables to annotate with unit specifications in 'tests/fixtures/Specification/Units/uninitialised.f90'
Successfully parsed 0 summary file(s).
Finished running unit critical variable analysis on input 'tests/fixtures/Specification/Units/uninitialised.f90' ...
Logs:

Result... OK:

tests/fixtures/Specification/Units/uninitialised.f90: 2 variable declarations suggested to be given a specification:
    tests/fixtures/Specification/Units/uninitialised.f90:7:13    initialised
    tests/fixtures/Specification/Units/uninitialised.f90:5:13    not_initialised
```


(with this branch of `fortran-src` https://github.com/camfort/fortran-src/pull/289)