### PR TITLE
Fixes to `units-compile` around including info from other mod files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0 (WIP)
+ * Fixed various bugs with cross-module behaviour for units-of-measure features
+ * All reports from camfort now produce location information in the form `filename:line:col` for better IDE integration.
+ * Updated to work with latest fortran-src
+
 ## 1.2.0 (Oct 12, 2022)
 
 * Improve CLI help behaviour

--- a/camfort.cabal
+++ b/camfort.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           camfort
-version:        1.2.0
+version:        1.3.0
 synopsis:       CamFort - Cambridge Fortran infrastructure
 description:    CamFort is a tool for the analysis, transformation, verification of Fortran code.
 category:       Language

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                   camfort
-version:                1.2.0
+version:                1.3.0
 synopsis:               CamFort - Cambridge Fortran infrastructure
 description:            CamFort is a tool for the analysis, transformation, verification of Fortran code.
 homepage:               https://camfort.github.io

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -526,9 +526,12 @@ unitsCompile opts uninits env = do
             let fnPaths = [ fn | (_, Just fn) <- nxt ]
             newMods <- fmap concat . forM fnPaths $ \ modFn -> do
               case modFn of
+                -- If there is mod file already, load it in
                 FM.MOFSMod modFilePath -> do
                   putStrLn $ "Loading mod file " ++ modFilePath ++ "."
                   decodeOneModFile modFilePath
+
+                -- Otherwise, compile the source file
                 FM.MOFile fnPath -> do
                   tsStatus <- FM.checkTimestamps fnPath
                   case tsStatus of

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -523,27 +523,32 @@ unitsCompile opts uninits env = do
   let loop mg mods
         | nxt <- FM.takeNextMods mg
         , not (null nxt) = do
-            let fnPaths = [ fn | (_, Just (FM.MOFile fn)) <- nxt ]
-            newMods <- fmap concat . forM fnPaths $ \ fnPath -> do
-              tsStatus <- FM.checkTimestamps fnPath
-              case tsStatus of
-                FM.NoSuchFile -> do
-                  putStr $ "Does not exist: " ++ fnPath
-                  pure [FM.emptyModFile]
-                FM.ModFileExists modPath -> do
-                  putStrLn $ "Loading mod file " ++ modPath ++ "."
-                  decodeOneModFile modPath
-                FM.CompileFile -> do
-                  putStr $ "Summarising " ++ fnPath ++ "..."
-                  m_pf <- readParseSrcFile (ceFortranVersion env) mods fnPath
-                  case m_pf of
-                    Just (pf, _) -> do
-                      mod <- compileFileToMod mods pf
-                      putStrLn "done"
-                      pure [mod]
-                    Nothing -> do
-                      putStrLn "failed"
-                      pure []
+            let fnPaths = [ fn | (_, Just fn) <- nxt ]
+            newMods <- fmap concat . forM fnPaths $ \ modFn -> do
+              case modFn of
+                FM.MOFSMod modFilePath -> do
+                  putStrLn $ "Loading mod file " ++ modFilePath ++ "."
+                  decodeOneModFile modFilePath
+                FM.MOFile fnPath -> do
+                  tsStatus <- FM.checkTimestamps fnPath
+                  case tsStatus of
+                    FM.NoSuchFile -> do
+                      putStr $ "Does not exist: " ++ fnPath
+                      pure [FM.emptyModFile]
+                    FM.ModFileExists modPath -> do
+                      putStrLn $ "Loading mod file " ++ modPath ++ "."
+                      decodeOneModFile modPath
+                    FM.CompileFile -> do
+                      putStr $ "Summarising " ++ fnPath ++ "..."
+                      m_pf <- readParseSrcFile (ceFortranVersion env) mods fnPath
+                      case m_pf of
+                        Just (pf, _) -> do
+                          mod <- compileFileToMod mods pf
+                          putStrLn "done"
+                          pure [mod]
+                        Nothing -> do
+                          putStrLn "failed"
+                          pure []
 
             let ns  = map fst nxt
             let mg' = FM.delModNodes ns mg

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -586,7 +586,7 @@ commandParser currDir =
 
 -- | Current CamFort version.
 version :: String
-version = "1.2.0"
+version = "1.3.0"
 
 
 -- | Full CamFort version string.

--- a/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
@@ -55,7 +55,6 @@ unitsCriticalsReportIs litmode uninitmode modNames fileName expectedReport = do
   where uOpts = unitOpts0 { uoLiterals = litmode, uninitializeds = uninitmode }
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
-
 mkTestModFile :: UnitOpts -> String -> IO ModFile
 mkTestModFile uopts file =
   head <$> genModFiles Nothing emptyModFiles compileUnits uopts file []

--- a/tests/Camfort/Specification/Units/Analysis/InferSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/InferSpec.hs
@@ -1,6 +1,7 @@
 module Camfort.Specification.Units.Analysis.InferSpec (spec) where
 
 import System.FilePath ((</>))
+import System.Directory (removeFile)
 
 import Control.Lens
 
@@ -9,12 +10,14 @@ import qualified Test.Hspec as Test
 
 import Language.Fortran.Util.ModFile (ModFile, emptyModFiles)
 
+import Camfort.Functionality (CamfortEnv(..),unitsCompile)
 import Camfort.Analysis hiding (describe)
 import Camfort.Analysis.ModFile (genModFiles, readParseSrcDir)
 import Camfort.Specification.Units.Analysis (compileUnits)
 import Camfort.Specification.Units.Analysis.Infer (inferUnits)
 import Camfort.Specification.Units.Monad
   (LiteralsOpt(..), unitOpts0, uoLiterals, runUnitAnalysis, UnitEnv(..))
+import Language.Fortran.Version (FortranVersion(..))
 
 spec :: Test.Spec
 spec =
@@ -61,8 +64,7 @@ spec =
       it "with literals" $
         unitsInferReportWithMod ["cross-module-b/cross-module-b1.f90"] "cross-module-b/cross-module-b2.f90"
           crossModuleBReport
-
-
+      it "units-suggest per file vs whole directory" singleFileVsDirectory
 
 fixturesDir :: String
 fixturesDir = "tests" </> "fixtures" </> "Specification" </> "Units"
@@ -73,20 +75,27 @@ unitsInferReportIs fileName expectedReport = do
   unitsInferReportWithMod [] fileName expectedReport
 
 -- | Assert that the report of performing units inference on a file is as expected (with mod files).
-unitsInferReportWithMod :: [String] -> String -> String -> Expectation
-unitsInferReportWithMod modNames fileName expectedReport = do
-  let file = fixturesDir </> fileName
-      modPaths = fmap (fixturesDir </>) modNames
+unitsInferReportWithModAux :: LiteralsOpt -> [String] -> String -> IO String
+unitsInferReportWithModAux litmod modPaths file = do      
   modFiles <- mapM mkTestModFile modPaths
-  [(pf,_)] <- readParseSrcDir Nothing modFiles file []
+  out <- readParseSrcDir Nothing modFiles file []
+  putStrLn $ show out
+
+  let [(pf,_)] = out
 
   let uEnv = UnitEnv { unitOpts = uOpts, unitProgramFile = pf }
 
   report <- runAnalysisT file (logOutputNone True) LogError modFiles $ runUnitAnalysis uEnv $ inferUnits
   let res = report ^?! arResult . _ARSuccess
+  return $ show res
+  where uOpts = unitOpts0 { uoLiterals = litmod }
 
-  show res `shouldBe` expectedReport
-  where uOpts = unitOpts0 { uoLiterals = LitMixed }
+-- | Assert that the report of performing units inference on a file is as expected (with mod files).
+unitsInferReportWithMod :: [String] -> String -> String -> Expectation
+unitsInferReportWithMod modNames fileName expectedReport = do
+  let modPaths = fmap (fixturesDir </>) modNames
+  res <- unitsInferReportWithModAux LitMixed modPaths (fixturesDir </> fileName)
+  res `shouldBe` expectedReport
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
 mkTestModFile :: String -> IO ModFile
@@ -99,6 +108,40 @@ exampleInferSimple1Report =
 
 inferReport :: String -> String -> String
 inferReport fname res = concat ["\n", fixturesDir </> fname, ":\n", res]
+
+
+singleFileVsDirectory :: Expectation
+singleFileVsDirectory = do
+  -- Top-level directory
+  let fixturesDir1 = fixturesDir </> "cross-module-d"
+  -- Main file
+  let mainFile = fixturesDir1 </> "main.f90"
+  -- and its dependencies
+  let dependencies = [ fixturesDir1 </> "constants.f90", fixturesDir1 </> "functions.f90" ]
+  let dependenciesMods = [ fixturesDir1 </> "constants.fsmod", fixturesDir1 </> "functions.fsmod" ]
+  -- Setup the environment
+  let literalsOpt = LitPoly
+  let camFortEnv file = CamfortEnv { ceInputSources = file
+                                    , ceIncludeDir = Nothing
+                                    , ceExcludeFiles = []
+                                    , ceLogLevel = LogError
+                                    , ceSourceSnippets = False
+                                    , ceFortranVersion = Just Fortran90 }
+  -- Compile the dependencies
+  mapM_ (\file -> unitsCompile literalsOpt False (camFortEnv file)) dependencies
+  -- Infer for the main file
+  singeFileOutput <- unitsInferReportWithModAux LitPoly dependenciesMods mainFile
+
+  -- Infer for the whole directory
+  -- Remove the existing dependencies' mod files
+  mapM_ removeFile dependenciesMods
+  -- Compile the whole directory
+  unitsCompile literalsOpt False (camFortEnv fixturesDir1)
+  -- Now do inference
+  multipeFileOutput <- unitsInferReportWithModAux LitPoly dependenciesMods mainFile
+
+  -- Compare the results
+  singeFileOutput `shouldBe` multipeFileOutput
 
 squarePoly1Report :: String
 squarePoly1Report = "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "squarePoly1.f90:4:11 unit m**2 :: x\n\

--- a/tests/fixtures/Specification/Units/cross-module-d/constants.f90
+++ b/tests/fixtures/Specification/Units/cross-module-d/constants.f90
@@ -1,0 +1,8 @@
+module constants
+
+  implicit none
+
+  != unit km / m :: km_per_m
+  real :: km_per_m = 0.001
+
+end

--- a/tests/fixtures/Specification/Units/cross-module-d/functions.f90
+++ b/tests/fixtures/Specification/Units/cross-module-d/functions.f90
@@ -1,0 +1,19 @@
+module functions
+
+  implicit none
+
+contains
+
+  function convert(length_m) result(length_km)
+      
+      use constants
+
+      real :: length_m
+      real :: length_km
+      
+      ! convert using constant from sub-module
+      length_km = length_m * km_per_m
+
+  end
+  
+end

--- a/tests/fixtures/Specification/Units/cross-module-d/main.f90
+++ b/tests/fixtures/Specification/Units/cross-module-d/main.f90
@@ -1,0 +1,16 @@
+program main
+
+  use functions
+
+  implicit none
+
+  != unit m :: length_m
+  real :: length_m = 5.0
+
+  ! units? 
+  real :: length_km
+
+  ! convert from m to km
+  length_km = convert(length_m)
+
+end 


### PR DESCRIPTION
This PR fixes issue https://github.com/camfort/camfort/issues/190 
so that doing `units-compile` on multiple files by hand is the equivalent to `units-compile` on the whole directory.