### PR TITLE
Update Nix build to use GHC 9.6 with working dependencies

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    name: build, build .#camfort-image-ghc92
+    name: build, build .#camfort-image-ghc96
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     # configure this output in flake.nix
     # make sure you know how it's tagged to then reference when pushing (don't
     # know a better method)
-    - run: nix build .#camfort-image-ghc92
+    - run: nix build .#camfort-image-ghc96
 
     - run: ./result | podman load
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,8 @@
           maxLayers = 120; # less than Docker max layers to allow extending
         };
       in {
-        packages.default  = self'.packages.camfort-ghc92-camfort;
-        devShells.default = self'.devShells.camfort-ghc92;
+        packages.default  = self'.packages.camfort-ghc96-camfort;
+        devShells.default = self'.devShells.camfort-ghc96;
 
         haskellProjects.ghc92 = import ./haskell-flake-ghc92.nix pkgs;
         haskellProjects.camfort-ghc92 = {
@@ -103,8 +103,71 @@
           };
         };
 
+        haskellProjects.ghc96 = import ./haskell-flake-ghc96.nix pkgs;
+        haskellProjects.camfort-ghc96 = {
+          basePackages = config.haskellProjects.ghc96.outputs.finalPackages;
+          packages = {
+            # Use whatever sbv version is available in nixpkgs for GHC 9.6
+            # sbv.source = "10.12"; # removed - causes version conflicts
+
+            # Use verifiable-expressions from GitHub
+            verifiable-expressions.source = pkgs.fetchFromGitHub {
+              owner = "camfort";
+              repo = "verifiable-expressions";
+              rev = "v0.6.3";
+              sha256 = "sha256-OqtTnmQhtODcbOQHaokSAi5h2rQS9Rj43YfqXAfOzLw=";
+            };
+
+            # Use fortran-src from GitHub for latest GHC compatibility
+            fortran-src.source = pkgs.fetchFromGitHub {
+              owner = "camfort";
+              repo = "fortran-src";
+              rev = "f5141b8ea86506690cd88de1884c1b97193cd477";
+              sha256 = "sha256-DpY+Yl9lDRhLTLLx5SYcr6lF+8i9TbdAVtPecWGSUAI=";
+            };
+          };
+
+          settings = {
+            sbv = {
+              # 2024-09-13 raehik: huge tests, some fail, seems complex. disable
+              # and just assume it's working
+              check = false;
+              
+              # sbv is marked as broken in nixpkgs, but we need it
+              broken = false;
+              
+              # sbv-10.2 violates <10 bounds in some dependencies
+              jailbreak = true;
+
+              # if we override the nixpkgs sbv derivation, we need to set this
+              extraLibraries = [pkgs.z3];
+            };
+            # this might not be needed if we don't override the nixpkgs sbv
+            # derivation? but it defo is if we do & seems a sensible default
+            camfort.extraLibraries = [pkgs.z3];
+
+            # 2024-09-12 raehik: temp TODO
+            union.broken = false;
+            union.jailbreak = true;
+          };
+
+          devShell = {
+            tools = hp: {
+              # use nixpkgs cabal-install
+              cabal-install = pkgs.cabal-install;
+
+              # disable these while unused (often slow/annoying to build)
+              haskell-language-server = null;
+              ghcid = null;
+              hlint = null;
+            };
+          };
+        };
+
         packages.camfort-image-ghc92 =
           mkCamfortImage "camfort" self'.packages.camfort-ghc92-camfort;
+        packages.camfort-image-ghc96 =
+          mkCamfortImage "camfort" self'.packages.camfort-ghc96-camfort;
       };
     };
 }

--- a/haskell-flake-ghc96.nix
+++ b/haskell-flake-ghc96.nix
@@ -1,0 +1,25 @@
+pkgs: {
+  # disable local project options (always do this for package sets)
+  defaults.packages = {};
+  devShell.enable = false;
+  autoWire = [];
+
+  basePackages = pkgs.haskell.packages.ghc96;
+  packages = {
+    # Let nixpkgs choose compatible versions for GHC 9.6
+    # CamFort only requires singletons* >= 3.0 according to package.yaml
+  };
+
+  # (note this is actually unused/we have to duplicate because it doesn't get
+  # packed into basePackages or any key we can use... but nice to document here)
+  devShell = {
+    tools = hp: {
+      # by default, haskell-flake uses the Haskell packages versions of these
+      # tools (from hp). be warned, these can be a pain to build alternatively,
+      # you may use nixpkgs versions via pkgs
+
+      # use nixpkgs cabal-install (shouldn't really matter how built)
+      cabal-install = pkgs.cabal-install;
+    };
+  };
+}


### PR DESCRIPTION
- Upgrade from GHC 9.2 to GHC 9.6 for better ecosystem support
- Fetch fortran-src from GitHub (commit f5141b8) for GHC 9.6+ compatibility
- Fetch verifiable-expressions v0.6.3 from GitHub (not in Hackage)
- Add necessary jailbreak overrides for packages with restrictive bounds:
  - union: jailbreak for newer base library compatibility
  - sbv: mark as not broken and jailbreak for version bounds
- Update GitHub workflow to build GHC 9.6 Docker images
- Add haskell-flake-ghc96.nix configuration file

This resolves build issues caused by version incompatibilities and packages not yet available in Hackage while upgrading to a more recent GHC version.