### PR TITLE
Complete fortran-src 0.17 integration with hash-based ModFile checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # sandbox files
 /.cabal-sandbox
 /cabal.sandbox.config
+/cabal.project.local
 
 # vim backup files
 .*.swp

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages:
+  .
+
+source-repository-package
+  type: git
+  location: https://github.com/camfort/fortran-src.git
+  tag: storeBaseNames

--- a/camfort.cabal
+++ b/camfort.cabal
@@ -366,7 +366,7 @@ library
     , directory >=1.2 && <2
     , fgl >=5.6 && <5.9
     , filepath ==1.4.*
-    , fortran-src >=0.16.8
+    , fortran-src >=0.17
     , ghc-prim >=0.3.1.0 && <0.14
     , hmatrix ==0.20.*
     , lattices >=2.0.0 && <2.3
@@ -406,7 +406,7 @@ executable camfort
     , directory >=1.2 && <2
     , fgl >=5.6 && <5.9
     , filepath ==1.4.*
-    , fortran-src >=0.16.8
+    , fortran-src >=0.17
     , hmatrix ==0.20.*
     , lattices >=2.0.0 && <2.3
     , lens >=4.15.1 && <6
@@ -464,7 +464,7 @@ test-suite spec
     , directory >=1.2 && <2
     , fgl >=5.6 && <5.9
     , filepath ==1.4.*
-    , fortran-src >=0.16.8
+    , fortran-src >=0.17
     , hmatrix ==0.20.*
     , hspec >=2.2 && <3
     , lattices >=2.0.0 && <2.3

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ dependencies:
   - text >= 0.11.2.3 && < 2.2
   - mtl >= 2.1 && < 2.4
   - containers >= 0.5.0.0 && < 0.7
-  - fortran-src >= 0.16.8
+  - fortran-src >= 0.17
   - filepath ==1.4.*
   - fgl >= 5.6 && < 5.9
   - lattices >= 2.0.0 && < 2.3

--- a/src/Camfort/Analysis/ModFile.hs
+++ b/src/Camfort/Analysis/ModFile.hs
@@ -65,23 +65,26 @@ import           Prelude                            hiding (mod)
 
 -- | Compiler for ModFile information, parameterised over an underlying monad
 -- and the input to the compiler.
-type MFCompiler r m = r -> FM.ModFiles -> F.ProgramFile A -> m FM.ModFile
+type MFCompiler r m = r -> FM.ModFiles -> SourceText -> F.ProgramFile A -> m FM.ModFile
 
 -- | Compile the Modfile with only basic information.
 simpleCompiler :: (Monad m) => MFCompiler () m
-simpleCompiler () mfs = return . FM.genModFile . fst' . withCombinedEnvironment mfs
+simpleCompiler () mfs src = return . FM.genModFile (FM.computeSourceHash src) . fst' . withCombinedEnvironment mfs
   where fst' (x, _, _) = x
 
-genCModFile :: MFCompiler r m -> r -> FM.ModFiles -> F.ProgramFile A -> m FM.ModFile
+genCModFile :: MFCompiler r m -> r -> FM.ModFiles -> SourceText -> F.ProgramFile A -> m FM.ModFile
 genCModFile = id
 
 -- | Generate mod files based on the given mod file compiler
+-- Returns pairs of (source file path, ModFile) to preserve path information
 genModFiles
   :: (MonadIO m)
-  => Maybe FortranVersion -> FM.ModFiles -> MFCompiler r m -> r -> FilePath -> [Filename] -> m FM.ModFiles
+  => Maybe FortranVersion -> FM.ModFiles -> MFCompiler r m -> r -> FilePath -> [Filename] -> m [(FilePath, FM.ModFile)]
 genModFiles mv mfs mfc opts fp excludes = do
-  fortranFiles <- liftIO $ fmap fst <$> readParseSrcDir mv mfs fp excludes
-  traverse (genCModFile mfc opts mfs) fortranFiles
+  fortranFiles <- liftIO $ readParseSrcDir mv mfs fp excludes
+  traverse (\(pf, src) -> do
+    modFile <- genCModFile mfc opts mfs src pf
+    return (F.pfGetFilename pf, modFile)) fortranFiles
 
 -- | Generate mod files based on the given mod file compiler (Pipes version)
 genModFilesP
@@ -89,11 +92,11 @@ genModFilesP
   => Maybe FortranVersion -> FM.ModFiles -> MFCompiler r m -> r -> [FilePath] -> Producer' FM.ModFile m ()
 genModFilesP mv mfs mfc opts files = parse >-> compile
   where
-    compile = P.mapM (genCModFile mfc opts mfs)
+    compile = P.mapM (\(pf, src) -> genCModFile mfc opts mfs src pf)
     parse = for (each files) $ \ file -> do
       mProgSrc <- liftIO $ readParseSrcFile mv mfs file
       case mProgSrc of
-        Just (pf, _) -> yield pf
+        Just progSrc -> yield progSrc
         Nothing -> pure ()
 
 

--- a/src/Camfort/Functionality.hs
+++ b/src/Camfort/Functionality.hs
@@ -338,10 +338,10 @@ ddtCompile env = do
   modFileNames <- getModFiles incDir
 
   -- Run the gen mod file routine directly on the input source
-  modFiles <- genModFiles (ceFortranVersion env) modFileNames DDT.compile () (ceInputSources env) (ceExcludeFiles env)
+  modFilesWithPaths <- genModFiles (ceFortranVersion env) modFileNames DDT.compile () (ceInputSources env) (ceExcludeFiles env)
   -- Write the mod files out
-  forM_ modFiles $ \ modFile -> do
-     let mfname = replaceExtension (FM.moduleFilename modFile) FM.modFileSuffix
+  forM_ modFilesWithPaths $ \ (sourcePath, modFile) -> do
+     let mfname = replaceExtension sourcePath FM.modFileSuffix
      LB.writeFile mfname (FM.encodeModFile [modFile])
   return 0
 
@@ -513,9 +513,10 @@ unitsCompile opts uninits env = do
   -- Build the graph of module dependencies
   mg0 <- FM.genModGraph (ceFortranVersion env) [incDir] Nothing paths'
 
-  let compileFileToMod mods pf = do
-        mod <- compileUnits uo mods pf
-        let mfname = replaceExtension (FM.moduleFilename mod) FM.modFileSuffix
+  let compileFileToMod mods src pf sourcePath = do
+        mod <- compileUnits uo mods src pf
+        -- Use the original source path to determine where to write the .fsmod file
+        let mfname = replaceExtension sourcePath FM.modFileSuffix
         LB.writeFile mfname (FM.encodeModFile [mod])
         pure mod
 
@@ -523,27 +524,35 @@ unitsCompile opts uninits env = do
   let loop mg mods
         | nxt <- FM.takeNextMods mg
         , not (null nxt) = do
-            let fnPaths = [ fn | (_, Just (FM.MOFile fn)) <- nxt ]
-            newMods <- fmap concat . forM fnPaths $ \ fnPath -> do
-              tsStatus <- FM.checkTimestamps fnPath
-              case tsStatus of
-                FM.NoSuchFile -> do
-                  putStr $ "Does not exist: " ++ fnPath
-                  pure [FM.emptyModFile]
-                FM.ModFileExists modPath -> do
-                  putStrLn $ "Loading mod file " ++ modPath ++ "."
-                  decodeOneModFile modPath
-                FM.CompileFile -> do
-                  putStr $ "Summarising " ++ fnPath ++ "..."
-                  m_pf <- readParseSrcFile (ceFortranVersion env) mods fnPath
-                  case m_pf of
-                    Just (pf, _) -> do
-                      mod <- compileFileToMod mods pf
-                      putStrLn "done"
-                      pure [mod]
-                    Nothing -> do
-                      putStrLn "failed"
-                      pure []
+            let fnPaths = [ fn | (_, Just fn) <- nxt ]
+            newMods <- fmap concat . forM fnPaths $ \ modFn -> do
+              case modFn of
+                -- If there is mod file already, load it in
+                FM.MOFSMod modFilePath -> do
+                  putStrLn $ "Loading mod file " ++ modFilePath ++ "."
+                  decodeOneModFile modFilePath
+
+                -- Otherwise, compile the source file
+                FM.MOFile fnPath -> do
+                  hashStatus <- FM.checkModFileHash fnPath
+                  case hashStatus of
+                    FM.NoSuchFile -> do
+                      putStr $ "Does not exist: " ++ fnPath
+                      pure [FM.emptyModFile]
+                    FM.ModFileExists modPath -> do
+                      putStrLn $ "Loading mod file " ++ modPath ++ "."
+                      decodeOneModFile modPath
+                    FM.CompileFile -> do
+                      putStr $ "Summarising " ++ fnPath ++ "..."
+                      m_pf <- readParseSrcFile (ceFortranVersion env) mods fnPath
+                      case m_pf of
+                        Just (pf, src) -> do
+                          mod <- compileFileToMod mods src pf fnPath
+                          putStrLn "done"
+                          pure [mod]
+                        Nothing -> do
+                          putStrLn "failed"
+                          pure []
 
             let ns  = map fst nxt
             let mg' = FM.delModNodes ns mg

--- a/src/Camfort/Input.hs
+++ b/src/Camfort/Input.hs
@@ -277,6 +277,7 @@ loadModAndProgramFiles
   -> m (ModFiles, [(ProgramFile, SourceText)])
 loadModAndProgramFiles mv mfc env inSrc incDir excludes = do
   liftIO $ printExcludes inSrc excludes
-  modFiles <- genModFiles mv emptyModFiles mfc env incDir excludes
+  modFilesWithPaths <- genModFiles mv emptyModFiles mfc env incDir excludes
+  let modFiles = map snd modFilesWithPaths
   ps <- liftIO $ readParseSrcDir mv modFiles inSrc excludes
   pure (modFiles, ps)

--- a/src/Camfort/Specification/DerivedDataType.hs
+++ b/src/Camfort/Specification/DerivedDataType.hs
@@ -64,6 +64,7 @@ import qualified Language.Fortran.Analysis.DataFlow as FAD
 import qualified Language.Fortran.Analysis.Types as FAT
 import           Language.Fortran.Util.ModFile
 import qualified Language.Fortran.Util.Position as FU
+import           Camfort.Helpers (SourceText)
 import           Prelude hiding (unlines, minBound, maxBound)
 import           Language.Fortran.Repr (fromConstInt)
 
@@ -329,10 +330,10 @@ refactor pfs = do
       else return (report', Right . stripAnnotations $ refactorPF report' pf')
 
 -- | Compile a program to a 'ModFile' containing derived datatype information.
-compile :: () -> ModFiles -> F.ProgramFile A -> IO ModFile
-compile _ mfs pf = do
+compile :: () -> ModFiles -> SourceText -> F.ProgramFile A -> IO ModFile
+compile _ mfs src pf = do
   let (report, pf') = genProgramFileReport mfs pf
-  return $ genDDTModFile pf' report
+  return $ genDDTModFile src pf' report
 
 --------------------------------------------------
 -- Analysis helpers
@@ -746,8 +747,8 @@ mstrength (x, my) = fmap (x,) my
 -- Compilation helpers
 
 -- | Generate a new ModFile containing derived datatype information.
-genDDTModFile :: Data a => F.ProgramFile (FA.Analysis a) -> DerivedDataTypeReport -> ModFile
-genDDTModFile pf ddtr = alterModFileData f ddtCompiledDataLabel $ genModFile pf
+genDDTModFile :: Data a => SourceText -> F.ProgramFile (FA.Analysis a) -> DerivedDataTypeReport -> ModFile
+genDDTModFile src pf ddtr = alterModFileData f ddtCompiledDataLabel $ genModFile (computeSourceHash src) pf
   where
     f _ = Just $ encode ddtr
 

--- a/src/Camfort/Specification/Units/Analysis.hs
+++ b/src/Camfort/Specification/Units/Analysis.hs
@@ -28,6 +28,7 @@ import           Camfort.Analysis.Annotations (Annotation)
 import           Camfort.Analysis.CommentAnnotator (annotateComments)
 import           Camfort.Analysis.Logger (LogLevel(..))
 import           Camfort.Analysis.ModFile (withCombinedEnvironment)
+import           Camfort.Helpers (SourceText)
 import qualified Camfort.Specification.Units.Annotation as UA
 import           Camfort.Specification.Units.Environment
 import           Camfort.Specification.Units.InferenceBackend
@@ -1093,8 +1094,8 @@ intrinsicUnits =
 -- Others: reshape, merge need special handling
 
 -- | Compile a program to a 'ModFile' containing units information.
-compileUnits :: UnitOpts -> ModFiles -> F.ProgramFile Annotation -> IO ModFile
-compileUnits uo mfs pf = do
+compileUnits :: UnitOpts -> ModFiles -> SourceText -> F.ProgramFile Annotation -> IO ModFile
+compileUnits uo mfs src pf = do
   let (pf', _, _) = withCombinedEnvironment mfs . fmap UA.mkUnitAnnotation $ pf
 
   let analysis = runReaderT (runInference runCompileUnits) $
@@ -1106,5 +1107,5 @@ compileUnits uo mfs pf = do
   report <- runAnalysisT (F.pfGetFilename pf) (logOutputNone True) LogError mfs analysis
 
   case report ^? arResult . _ARSuccess . _1 of
-    Just cu -> return (genUnitsModFile pf' cu)
+    Just cu -> return (genUnitsModFile src pf' cu)
     Nothing -> fail "compileUnits: units analysis failed"

--- a/src/Camfort/Specification/Units/ModFile.hs
+++ b/src/Camfort/Specification/Units/ModFile.hs
@@ -38,6 +38,7 @@ import           GHC.Generics (Generic)
 import qualified Language.Fortran.AST as F
 import qualified Language.Fortran.Analysis as FA
 import           Language.Fortran.Util.ModFile
+import           Camfort.Helpers (SourceText)
 import           Prelude hiding (mod)
 
 -- | The data-structure stored in 'fortran-src mod files'
@@ -145,8 +146,8 @@ optimiseTemplate cons = map (\ (l, r) -> ConEq (foldUnits l) r) optimised
     compileColSort = flip colSort
 
 -- | Generate a new ModFile containing Units information.
-genUnitsModFile :: F.ProgramFile UA -> CompiledUnits -> ModFile
-genUnitsModFile pf cu = alterModFileData f unitsCompiledDataLabel $ genModFile pf
+genUnitsModFile :: SourceText -> F.ProgramFile UA -> CompiledUnits -> ModFile
+genUnitsModFile src pf cu = alterModFileData f unitsCompiledDataLabel $ genModFile (computeSourceHash src) pf
   where
     f _ = Just $ encode cu
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,4 +14,5 @@ extra-deps:
 - vinyl-0.14.3@sha256:08565c5d9ed8a5ba69915bffe8960f048587478155d5915a56d2e93b8ba3466f,4267
 - verifiable-expressions-0.6.3@sha256:f0a8221e57356c4675500d1e499c38994b69e7ffb0270e69e78d35b0de29636c,1960
 - union-0.1.2
-- fortran-src-0.16.8@sha256:6587c88ca0c98dfa52b18d0f4c0336db245a4adb5bd9415b88f2267ebb470a71,12906
+- git: https://github.com/camfort/fortran-src.git
+  commit: storeBaseNames

--- a/tests/Camfort/Specification/DerivedDataTypeSpec.hs
+++ b/tests/Camfort/Specification/DerivedDataTypeSpec.hs
@@ -27,7 +27,7 @@ ddtInferReport modNames fileName = do
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
 mkTestModFile :: String -> IO ModFile
-mkTestModFile file = head <$> genModFiles Nothing emptyModFiles compile () file []
+mkTestModFile file = snd . head <$> genModFiles Nothing emptyModFiles compile () file []
 
 spec :: Test.Spec
 spec = do

--- a/tests/Camfort/Specification/StencilsSpec.hs
+++ b/tests/Camfort/Specification/StencilsSpec.hs
@@ -461,7 +461,7 @@ inferReportWithMod modNames fileName expectedReport = do
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
 mkTestModFile :: String -> IO ModFile
-mkTestModFile file = head <$> genModFiles Nothing emptyModFiles compileStencils () file []
+mkTestModFile file = snd . head <$> genModFiles Nothing emptyModFiles compileStencils () file []
 
 crossModuleAUserReport :: [L.Text]
 crossModuleAUserReport =

--- a/tests/Camfort/Specification/Units/Analysis/ConsistentSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/ConsistentSpec.hs
@@ -79,7 +79,7 @@ unitsCheckReportIs = unitsCheckReport LitMixed []
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
 mkTestModFile :: String -> IO ModFile
-mkTestModFile file = head <$> genModFiles Nothing emptyModFiles compileUnits unitOpts0 file []
+mkTestModFile file = snd . head <$> genModFiles Nothing emptyModFiles compileUnits unitOpts0 file []
 
 exampleInconsist1CheckReport :: String
 exampleInconsist1CheckReport =

--- a/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/CriticalsSpec.hs
@@ -58,7 +58,7 @@ unitsCriticalsReportIs litmode uninitmode modNames fileName expectedReport = do
 
 mkTestModFile :: UnitOpts -> String -> IO ModFile
 mkTestModFile uopts file =
-  head <$> genModFiles Nothing emptyModFiles compileUnits uopts file []
+  snd . head <$> genModFiles Nothing emptyModFiles compileUnits uopts file []
 
 exampleCriticals1CriticalsReport :: String
 exampleCriticals1CriticalsReport =
@@ -73,8 +73,8 @@ exampleCriticals2CriticalsReport =
 exampleCriticals3CriticalsReport :: String
 exampleCriticals3CriticalsReport =
  "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90: 6 variable declarations suggested to be given a specification:\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:7:10    b\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:13:12    d\n\
+ \    cross-module-c1.f90:7:10    b\n\
+ \    cross-module-c1.f90:13:12    d\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:5:10    a3\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:9:10    b3\n\
  \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c3.f90:11:10    x0\n\
@@ -83,13 +83,13 @@ exampleCriticals3CriticalsReport =
 exampleCriticals4CriticalsReport :: String
 exampleCriticals4CriticalsReport =
  "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90: 7 variable declarations suggested to be given a specification:\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:5:16    a\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:7:10    b\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:11:12    foo_out\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:18:12    foo3\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:24:14    x\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:30:12    foo5\n\
- \    tests" </> "fixtures" </> "Specification" </> "Units" </> "cross-module-c" </> "cross-module-c1.f90:31:12    x\n"
+ \    cross-module-c1.f90:5:16    a\n\
+ \    cross-module-c1.f90:7:10    b\n\
+ \    cross-module-c1.f90:11:12    foo_out\n\
+ \    cross-module-c1.f90:18:12    foo3\n\
+ \    cross-module-c1.f90:24:14    x\n\
+ \    cross-module-c1.f90:30:12    foo5\n\
+ \    cross-module-c1.f90:31:12    x\n"
 
 exampleCriticalUninitMixed :: String
 exampleCriticalUninitMixed =

--- a/tests/Camfort/Specification/Units/Analysis/InferSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/InferSpec.hs
@@ -1,6 +1,8 @@
 module Camfort.Specification.Units.Analysis.InferSpec (spec) where
 
 import System.FilePath ((</>))
+import System.Directory (doesFileExist, removeFile)
+import Control.Monad (when)
 
 import Control.Lens
 
@@ -8,6 +10,7 @@ import           Test.Hspec hiding (Spec)
 import qualified Test.Hspec as Test
 
 import Language.Fortran.Util.ModFile (ModFile, emptyModFiles)
+import Language.Fortran.Version (FortranVersion(..))
 
 import Camfort.Analysis hiding (describe)
 import Camfort.Analysis.ModFile (genModFiles, readParseSrcDir)
@@ -16,6 +19,7 @@ import Camfort.Specification.Units.Analysis.Infer (inferUnits)
 import Camfort.Specification.Units.Monad
   (LiteralsOpt(..), unitOpts0, uoLiterals, runUnitAnalysis, UnitEnv(..))
 import Camfort.TestUtils (normalisedShouldBe)
+import Camfort.Functionality (unitsCompile, CamfortEnv(..))
 
 spec :: Test.Spec
 spec =
@@ -62,6 +66,8 @@ spec =
       it "with literals" $
         unitsInferReportWithMod ["cross-module-b/cross-module-b1.f90"] "cross-module-b/cross-module-b2.f90"
           crossModuleBReport
+      -- Disabled: fixture files for cross-module-d don't exist in repo
+      -- it "units-suggest per file vs whole directory" singleFileVsDirectory
 
 
 
@@ -89,9 +95,24 @@ unitsInferReportWithMod modNames fileName expectedReport = do
   show res `normalisedShouldBe` expectedReport
   where uOpts = unitOpts0 { uoLiterals = LitMixed }
 
+-- | Helper for running units inference with mod files and returning the report string.
+unitsInferReportWithModAux :: LiteralsOpt -> [String] -> String -> IO String
+unitsInferReportWithModAux litmod modPaths file = do
+  modFiles <- mapM mkTestModFile modPaths
+  out <- readParseSrcDir Nothing modFiles file []
+
+  let [(pf,_)] = out
+
+  let uEnv = UnitEnv { unitOpts = uOpts, unitProgramFile = pf }
+
+  report <- runAnalysisT file (logOutputNone True) LogError modFiles $ runUnitAnalysis uEnv $ inferUnits
+  let res = report ^?! arResult . _ARSuccess
+  return $ show res
+  where uOpts = unitOpts0 { uoLiterals = litmod }
+
 -- | Helper for producing a basic ModFile from a (terminal) module file.
 mkTestModFile :: String -> IO ModFile
-mkTestModFile file = head <$> genModFiles Nothing emptyModFiles compileUnits unitOpts0 file []
+mkTestModFile file = snd . head <$> genModFiles Nothing emptyModFiles compileUnits unitOpts0 file []
 
 exampleInferSimple1Report :: String
 exampleInferSimple1Report =
@@ -100,6 +121,46 @@ exampleInferSimple1Report =
 
 inferReport :: String -> String -> String
 inferReport fname res = concat ["\n", fixturesDir </> fname, ":\n", res]
+
+singleFileVsDirectory :: Expectation
+singleFileVsDirectory = do
+  -- Top-level directory
+  let fixturesDir1 = fixturesDir </> "cross-module-d"
+  -- Main file
+  let mainFile = fixturesDir1 </> "main.f90"
+  -- and its dependencies
+  let dependencies = [ fixturesDir1 </> "constants.f90", fixturesDir1 </> "functions.f90" ]
+  let dependenciesMods = [ fixturesDir1 </> "constants.fsmod", fixturesDir1 </> "functions.fsmod" ]
+  -- Clean up any stale .fsmod files from previous runs
+  mapM_ (\f -> doesFileExist f >>= \exists -> when exists (removeFile f)) dependenciesMods
+  -- Setup the environment
+  let literalsOpt = LitPoly
+  let camFortEnv file = CamfortEnv { ceInputSources = file
+                                    , ceIncludeDir = Nothing
+                                    , ceExcludeFiles = []
+                                    , ceLogLevel = LogError
+                                    , ceSourceSnippets = False
+                                    , ceFortranVersion = Just Fortran90 }
+  -- Compile the dependencies
+  mapM_ (\file -> unitsCompile literalsOpt False (camFortEnv file)) dependencies
+  -- Infer for the main file
+  singeFileOutput <- unitsInferReportWithModAux LitPoly dependencies mainFile
+
+  -- Infer for the whole directory
+  -- Remove the existing dependencies' mod files
+  mapM_ removeFile dependenciesMods
+  -- Compile the whole directory
+  unitsCompile literalsOpt False (camFortEnv fixturesDir1)
+  -- Now do inference
+  multipeFileOutput <- unitsInferReportWithModAux LitPoly dependencies mainFile
+
+  -- Clean up .fsmod files to avoid polluting other tests
+  mapM_ (\f -> doesFileExist f >>= \exists -> when exists (removeFile f)) dependenciesMods
+  let mainModFile = fixturesDir1 </> "main.fsmod"
+  doesFileExist mainModFile >>= \exists -> when exists (removeFile mainModFile)
+
+  -- Compare the results
+  singeFileOutput `shouldBe` multipeFileOutput
 
 squarePoly1Report :: String
 squarePoly1Report = "\ntests" </> "fixtures" </> "Specification" </> "Units" </> "squarePoly1.f90:4:10 unit m**2 :: x\n\

--- a/tests/Camfort/Specification/Units/Analysis/SuggestSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/SuggestSpec.hs
@@ -43,7 +43,7 @@ unitsSuggestReportIs litmode uninitmode modNames fileName expectedReport = do
 -- | Helper for producing a basic ModFile from a (terminal) module file.
 mkTestModFile :: UnitOpts -> String -> IO ModFile
 mkTestModFile uopts file =
-  head <$> genModFiles Nothing emptyModFiles compileUnits uopts file []
+  snd . head <$> genModFiles Nothing emptyModFiles compileUnits uopts file []
 
 expectedInternalsPolyReport :: String
 expectedInternalsPolyReport =

--- a/tests/Camfort/Specification/Units/Analysis/SynthSpec.hs
+++ b/tests/Camfort/Specification/Units/Analysis/SynthSpec.hs
@@ -54,7 +54,7 @@ unitsSynthReportWithMod modNames fileName expectedOutput = do
 
 -- | Helper for producing a basic ModFile from a (terminal) module file.
 mkTestModFile :: String -> IO ModFile
-mkTestModFile file = head <$> genModFiles Nothing emptyModFiles compileUnits unitOpts0 file []
+mkTestModFile file = snd . head <$> genModFiles Nothing emptyModFiles compileUnits unitOpts0 file []
 
 -- | Normalise output by trimming trailing whitespace from lines and handling CRLF
 normaliseOutput :: String -> String


### PR DESCRIPTION
This pull request shows what it takes to adapt CamFort for the `storeBaseNames` changes.


Updated CamFort to work with provisional fortran-src 0.17 having ModFile API changes (and `storeBaseNames` merged).

Key changes:
- genModFiles now returns [(FilePath, ModFile)] pairs to preserve source paths for correct .fsmod file placement
- compileFileToMod takes source path parameter to write .fsmod files in the right locations (not just basenames)
- All ModFile generation computes and passes SourceHash via computeSourceHash
- MFCompiler type updated to accept SourceText parameter

Hash-based checking replaces timestamp-based:
- checkModFileHash replaces checkTimestamps
- HashStatus replaces TimestampStatus
- Added handling for MOFSMod (pre-existing .fsmod files)

Test updates:
- Updated all test files to handle new genModFiles return type
- Fixed test expectations for basename-only cross-module references
- Disabled singleFileVsDirectory test (fixture files not in repo)
- Test cleanup now removes all generated .fsmod files

The fortran-src 0.17 API change exposed a bug in CamFort (now fixed):
- .fsmod file should be placed based on source paths, not ModFile paths.